### PR TITLE
Set ulimits with official recommended setting

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -71,9 +71,9 @@ fi
 #
 do_start()
 {
-	# 2012/07/23 Kazuki Ohta <k@treasure-data.com>
 	# Set Max number of file descriptors for the safety sake
-	ulimit -n 8192
+	# see http://docs.fluentd.org/en/articles/before-install
+	ulimit -n 65536
 
 	# Return
 	#   0 if daemon has been started

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -48,6 +48,9 @@ fi
 RETVAL=0
 
 start() {
+	# Set Max number of file descriptors for the safety sake
+	# see http://docs.fluentd.org/en/articles/before-install
+	ulimit -n 65536
 	echo -n "Starting $name: "
 	daemon --pidfile=$PIDFILE $DAEMON_ARGS $td_agent "$TD_AGENT_ARGS"
 	RETVAL=$?


### PR DESCRIPTION
Hi @repeatedly 
It has been recommended to raise ulimit in [official document](http://docs.fluentd.org/en/articles/before-install). But, it does not set in init.d script or not same.
So, It would be better to set `ulimit -n 65536` in init script.

Note: it is a same patch with this pull-req https://github.com/treasure-data/td-agent/pull/58
