### PR TITLE
Add flush buffer function for initscript

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -129,6 +129,14 @@ do_reload() {
 	return 0
 }
 
+#
+# Function that sends a USR1 Signal to the daemon/service
+#
+do_flush() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE --name ruby
+	return 0
+}
+
 do_configtest() {
 	eval "$DAEMON_ARGS --user ${USER} --group ${GROUP} --dry-run -q"
 }
@@ -185,12 +193,14 @@ case "$1" in
 		;;
 	esac
 	;;
+  flush)
+	do_flush
+	;;
   configtest)
 	do_configtest
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|flush|configtest|status}" >&2
 	exit 3
 	;;
 esac

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -117,6 +117,13 @@ reload() {
 	echo
 }
 
+flush() {
+	echo -n "Flushing buffer $name: "
+	killproc $td_agent -USR1
+	RETVAL=$?
+	echo
+}
+
 configtest() {
 	eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
 }
@@ -134,6 +141,9 @@ case "$1" in
     reload)
 	reload
 	;;
+    flush)
+	flush
+	;;
     condrestart)
 	[ -f /var/lock/subsys/$prog ] && restart || :
 	;;
@@ -144,7 +154,7 @@ case "$1" in
 	status -p $PIDFILE 'td-agent'
 	;;
     *)
-	echo "Usage: $prog {start|stop|reload|restart|condrestart|status|configtest}"
+	echo "Usage: $prog {start|stop|restart|reload|flush|condrestart|configtest|status}"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
Add USR1 Signal function to force flushing buffered events.
It could very useful for system failure troubleshooting to re-send buffer immidiately.
## usage

```
$ sudo service td-agent flush
```
## note

On adding `flush` function, it's a bit reordered the usage suggestion as these product does.

```
$ /etc/init.d/mysql
Usage: mysql  {start|stop|restart|reload|force-reload|status}  [ MySQL server options ]

$ /etc/init.d/rsyslog
Usage: /etc/init.d/rsyslog {start|stop|restart|condrestart|try-restart|reload|force-reload|status}
```
