### PR TITLE
Allow users to override variables from /etc/default or /etc/sysconfig

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -14,9 +14,6 @@
 # Introduce the short server's name here
 NAME=td-agent
 
-# Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
-
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 USER=td-agent                   # Running user
@@ -28,6 +25,9 @@ DAEMON=/opt/td-agent/embedded/bin/ruby # Introduce the server's location here
 DAEMON_ARGS="/usr/sbin/td-agent $DAEMON_ARGS --daemon $PIDFILE --log /var/log/td-agent/td-agent.log --use-v1-config"
 SCRIPTNAME=/etc/init.d/$NAME
 START_STOP_DAEMON_ARGS=""
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -26,12 +26,13 @@ td_agent=/opt/td-agent/embedded/bin/ruby
 # timeout can be overridden from /etc/sysconfig/td-agent
 STOPTIMEOUT=120
 
-if [ -f /etc/sysconfig/$prog ]; then
-	. /etc/sysconfig/$prog
-fi
 PIDFILE=${PIDFILE-/var/run/td-agent/$prog.pid}
 DAEMON_ARGS=${DAEMON_ARGS---user td-agent}
 TD_AGENT_ARGS="${TD_AGENT_ARGS-/usr/sbin/td-agent --group td-agent --log /var/log/td-agent/td-agent.log --use-v1-config}"
+
+if [ -f /etc/sysconfig/$prog ]; then
+	. /etc/sysconfig/$prog
+fi
 
 if [ -n "${PIDFILE}" ]; then
 	PIDFILE_DIR=$(dirname ${PIDFILE})


### PR DESCRIPTION
Init scripts should allow users to override the behaviour from /etc/default or /etc/sysconfig. This is as almost same fix as treasure-data/td-agent#57 .
