### PR TITLE
prevention of overwrite to project_root

### DIFF
--- a/config/software/td-agent-files.rb
+++ b/config/software/td-agent-files.rb
@@ -14,12 +14,14 @@ build do
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
     project_name_snake_upcase = project_name_snake.upcase
+    project_root = Omnibus::Config.project_root
     gem_dir_version = "2.1.0"
 
     template = -> (*parts) { File.join('templates', *parts) }
     generate_from_template = -> (dst, src, erb_binding, opts={}) {
       mode = opts.fetch(:mode, 0755)
-      destination = dst.gsub('td-agent', project.name)
+      dst.slice!(project_root)
+      destination = project_root + dst.gsub('td-agent', project.name)
       FileUtils.mkdir_p File.dirname(destination)
       File.open(destination, 'w', mode) do |f|
         f.write ERB.new(File.read(src)).result(erb_binding)


### PR DESCRIPTION
I fail to build. If, is including the word "td-agent" in the path.

e.g. 

`Omnibus::Config.project_root` is `/home/vagrant/omnibus-td-agent`
1. build for `my-agent`

```
bin/omnibus build my-agent
```
1. File is copied to another build path（`/home/vagrant/omnibus-my-agent`）

```
/home/vagrant/omnibus-my-agent/package-scripts/my-agent/postun
/home/vagrant/omnibus-my-agent/package-scripts/my-agent/preun
/home/vagrant/omnibus-my-agent/resources/my-agent/etc/init.d/my-agent
・
・
・
```

I want to not overwrite the project_root.
