### PR TITLE
fix rm: cannot remove ‘/etc/td-agent/plugin’: Is a directory

### DIFF
--- a/templates/package-scripts/td-agent/deb/postrm
+++ b/templates/package-scripts/td-agent/deb/postrm
@@ -3,7 +3,7 @@
 set -e
 
 if [ "$1" = "purge" ]; then
-        rm -f /etc/<%= project_name %>/*
+        rm -rf /etc/<%= project_name %>/*
         dpkg-statoverride --remove /etc/<%= project_name %>
 	rm -f /var/run/<%= project_name %>/*
         dpkg-statoverride --remove /var/run/<%= project_name %>


### PR DESCRIPTION
I install td-agent from
```
deb [arch=amd64] http://packages.treasuredata.com/2/ubuntu/trusty/ trusty contrib
```
when I use apt-get purge td-agent to remove the package, dpkg throw this error.

The deb package [postinst script in line 18](https://github.com/treasure-data/omnibus-td-agent/blob/master/templates/package-scripts/td-agent/deb/postinst#L18):
``` sh
mkdir -p /etc/td-agent/plugin
```
The [postrm script in line 6](https://github.com/treasure-data/omnibus-td-agent/blob/master/templates/package-scripts/td-agent/deb/postrm#L6):
``` sh
rm -f /etc/td-agent/*
```