### PR TITLE
add prerm for debian

### DIFF
--- a/templates/package-scripts/td-agent/deb/prerm
+++ b/templates/package-scripts/td-agent/deb/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -x "/etc/init.d/<%= project_name %>" ]; then
+	invoke-rc.d <%= project_name %> stop || exit $?
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
When I removed td-agent version 2 package, td-agent processes were still alive.
I had no choice but to do `kill PID`.
This patch removes package after stoping processes like td-agent version 1.