### PR TITLE
Fix lzma undefined issue at plugin installation on CentOS 7

### DIFF
--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -16,6 +16,10 @@ dependency "preparation"
 
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '2.2.1'
+# CentOS7 needs latest liblzma to build pg and some gems
+if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 7
+  override :liblzma, :version => '5.1.2alpha'
+end
 
 # td-agent dependencies/components
 dependency "td-agent"

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "liblzma"
+default_version "5.0.5"
+
+version('5.0.5') { source md5: "19d924e066b6fff0bc9d1981b4e53196" }
+version('5.1.2alpha') { source md5: "9bad1e249537ce69b206815cf28ca87b" }
+
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz"
+
+relative_path "xz-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --disable-debug" \
+          " --disable-dependency-tracking", env: env
+
+  make "install", env: env
+end


### PR DESCRIPTION
This patch is applied to td-agent 2.1.3-1.
