### PR TITLE
Exit as error if one of a commans exists with non-zero

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -10,6 +10,7 @@
 ### END INIT INFO
 
 # Author: Kazuki Ohta <k@treasure-data.com>
+set -e
 
 # Introduce the short server's name here
 NAME=td-agent

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -16,6 +16,8 @@
 # Description:       td-agent is a data collector
 ### END INIT INFO
 
+set -e
+
 # Source function library.
 . /etc/init.d/functions
 


### PR DESCRIPTION
Just added `set -e` at the beginning of the init scripts to exit as non-zero on some errors.