### PR TITLE
Remove spaces in lambda rockets for ruby 1.9

### DIFF
--- a/config/software/td-agent-files.rb
+++ b/config/software/td-agent-files.rb
@@ -16,8 +16,8 @@ build do
     project_name_snake_upcase = project_name_snake.upcase
     gem_dir_version = "2.1.0"
 
-    template = -> (*parts) { File.join('templates', *parts) }
-    generate_from_template = -> (dst, src, erb_binding, opts={}) {
+    template = ->(*parts) { File.join('templates', *parts) }
+    generate_from_template = ->(dst, src, erb_binding, opts={}) {
       mode = opts.fetch(:mode, 0755)
       destination = dst.gsub('td-agent', project.name)
       FileUtils.mkdir_p File.dirname(destination)

--- a/config/software/td-agent-ui.rb
+++ b/config/software/td-agent-ui.rb
@@ -16,8 +16,8 @@ build do
     project_name_snake_upcase = project_name_snake.upcase
     gem_dir_version = "2.1.0"
 
-    template = -> (*parts) { File.join('templates', *parts) }
-    generate_from_template = -> (dst, src, erb_binding, opts={}) {
+    template = ->(*parts) { File.join('templates', *parts) }
+    generate_from_template = ->(dst, src, erb_binding, opts={}) {
       mode = opts.fetch(:mode, 0755)
       destination = dst.gsub('td-agent', project.name)
       FileUtils.mkdir_p File.dirname(destination)

--- a/config/software/td.rb
+++ b/config/software/td.rb
@@ -15,8 +15,8 @@ build do
     project_name_snake_upcase = project_name_snake.upcase
     gem_dir_version = "2.1.0"
 
-    template = -> (*parts) { File.join('templates', *parts) }
-    generate_from_template = -> (dst, src, erb_binding, opts={}) {
+    template = ->(*parts) { File.join('templates', *parts) }
+    generate_from_template = ->(dst, src, erb_binding, opts={}) {
       mode = opts.fetch(:mode, 0755)
       destination = dst.gsub('td-agent', project.name)
       FileUtils.mkdir_p File.dirname(destination)


### PR DESCRIPTION
A space between '->' and '(' does not parse in ruby 1.9,
with no space it works in both 1.9 and 2.0+.