### PR TITLE
Stop fluentd init script from exiting on CentOS.

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -16,10 +16,10 @@
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO
 
-set -e
-
 # Source function library.
 . /etc/init.d/functions
+
+set -e
 
 name="<%= project_name %>"
 prog="<%= project_name %>"


### PR DESCRIPTION
Move 'set -e' to after we source /etc/init.d/functions,
because that file runs the /sbin/consoletype command which
has a weird exit value (non-0 unless running on console)
that causes the entire script to exit.

I checked this on centos 6/7 which do similar things, I
assume RHEL may do it as well.