### PR TITLE
Include PostgreSQL for pg related plugins

### DIFF
--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -16,6 +16,7 @@ dependency "preparation"
 
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '2.2.1'
+override :postgresql, :version => '9.3.5'
 # CentOS7 needs latest liblzma to build pg and some gems
 if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 7
   override :liblzma, :version => '5.1.2alpha'

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -1,0 +1,65 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "postgresql"
+default_version "9.2.9"
+
+dependency "zlib"
+dependency "openssl"
+dependency "libedit"
+dependency "ncurses"
+
+version "9.1.9" do
+  source md5: "6b5ea53dde48fcd79acfc8c196b83535"
+end
+
+version "9.2.8" do
+  source md5: "c5c65a9b45ee53ead0b659be21ca1b97"
+end
+
+version "9.2.9" do
+  source md5: "38b0937c86d537d5044c599273066cfc"
+end
+
+version "9.3.4" do
+  source md5: "d0a41f54c377b2d2fab4a003b0dac762"
+end
+
+version "9.3.5" do
+  source md5: "5059857c7d7e6ad83b6d55893a121b59"
+end
+
+version "9.4.0" do
+  source md5: "8cd6e33e1f8d4d2362c8c08bd0e8802b"
+end
+
+source url: "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+
+relative_path "postgresql-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --with-libedit-preferred" \
+          " --with-openssl" \
+          " --with-includes=#{install_dir}/embedded/include" \
+          " --with-libraries=#{install_dir}/embedded/lib", env: env
+
+  make "world -j #{workers}", env: env
+  make "install-world", env: env
+end

--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -4,6 +4,7 @@ name "td-agent"
 dependency "jemalloc"
 dependency "ruby"
 dependency "nokogiri"
+dependency "postgresql"
 dependency "fluentd"
 
 env = {}


### PR DESCRIPTION
Omnibus has own OpenSSL and it causes pg gem can't be installed
because pg gem depends on system OpenSSL.
We will remove own OpenSSL dependency from omnibus package.
This patch is for short-term approach to resolve pg gem issue.