### PR TITLE
Use meaningful display name `$NAME` instead of meaningless name `ruby`

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -191,7 +191,6 @@ case "$1" in
 		log_end_msg "$RETVAL"
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
 	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
 	exit 3
 	;;

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -152,7 +152,7 @@ case "$1" in
 	esac
 	;;
   status)
-       status_of_proc "$DAEMON" ruby
+       status_of_proc "$DAEMON" "$NAME"
        ;;
   reload|force-reload)
 	#


### PR DESCRIPTION
Currently, init.d script commands (`start`, `stop`, `reload`, `restart`) show meaningful display name `$NAME`.

However, the `status` command show meaningless display name `ruby`.

I think that all commands should show meaningful display name.