### PR TITLE
use omnibus from github

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -1,0 +1,1 @@
+append_timestamp false


### PR DESCRIPTION
I add the option `append_timestamp false` which avoids adding timestamp to `build_version` for latest `omnibus`.
