### PR TITLE
Remove 'set -e', as it's causing issues

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -19,8 +19,6 @@
 # Source function library.
 . /etc/init.d/functions
 
-set -e
-
 name="<%= project_name %>"
 prog="<%= project_name %>"
 process_bin=<%= install_path %>/embedded/bin/ruby


### PR DESCRIPTION
We've seen an issue on some installs with td-agent not running at system start up, even when enabled in chkconfig.

After some investigation, we've found that altering the init script and removing the 'set -e' or commenting out the echo call in start() solves the issue.

**If there is no clearly known reason why the 'set -e' is required it would be beneficial to us (and probably others) for it to be removed - if there is some requirement for exiting on error perhaps it could be handled differently?**

There is a mention of it being risky in the Debian documentation (we're running CentOS, but still...)

https://www.debian.org/doc/debian-policy/ch-opersys.html - 9.3.2 Writing the scripts

> Be careful of using set -e in init.d scripts. Writing correct init.d scripts requires accepting various error exit statuses when daemons are already running or already stopped without aborting the init.d script, and common init.d function libraries are not safe to call with set -e in effect[82]. For init.d scripts, it's often easier to not use set -e and instead check the result of each command separately.

It is also mentioned in the status section of this init script that there had been issues seen with 'set -e' usage elsewhere.