### PR TITLE
There should be tests even for init scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ package-scripts/td-agent/preinst
 package-scripts/td-agent/prerm
 files/etc/init.d/td-agent
 resources/td-agent/etc/init.d/td-agent
+
+# bats
+/bats/bats

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 require 'rake'
 require 'rspec/core/rake_task'
+require 'shellwords'
 
-task :spec    => 'spec:all'
+task :spec    => ['spec:all', 'bats:all']
 task :default => :spec
 
 namespace :spec do
@@ -20,5 +21,24 @@ namespace :spec do
       ENV['TARGET_HOST'] = target
       t.pattern = "spec/#{target}/*_spec.rb"
     end
+  end
+end
+
+namespace :bats do
+  bats_path = File.expand_path("../bats/bats", __FILE__)
+  test_path = File.expand_path("../bats", __FILE__)
+
+  desc "Run bats tests for init scripts"
+  task :all => [:setup, :run]
+  task :default => :all
+
+  task :setup do
+    unless File.exist?(bats_path)
+      sh "git clone https://github.com/sstephenson/bats.git #{Shellwords.shellescape(bats_path)}"
+    end
+  end
+
+  task :run do
+    sh "#{Shellwords.shellescape(File.join(bats_path, "bin", "bats"))} --tap #{Shellwords.shellescape(test_path)}"
   end
 end

--- a/bats/configtest_debian.bats
+++ b/bats/configtest_debian.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "configuration test success (debian)" {
+  stub_path /usr/sbin/td-agent "echo td-agent; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service configtest
+  assert_output <<EOS
+td-agent
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+  --user
+  td-agent
+  --group
+  td-agent
+  --dry-run
+  -q
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub log_end_msg
+}
+
+@test "configuration test failure (debian)" {
+  stub_path /usr/sbin/td-agent "false"
+  stub log_end_msg "1 : false"
+
+  run_service configtest
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub log_end_msg
+}

--- a/bats/configtest_redhat.bats
+++ b/bats/configtest_redhat.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "configuration test success (redhat)" {
+  stub_path /usr/sbin/td-agent "echo td-agent; for arg; do echo \"  \$arg\"; done"
+
+  run_service configtest
+  assert_output <<EOS
+td-agent
+  --group
+  td-agent
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --user
+  td-agent
+  --dry-run
+  -q
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+}
+
+@test "configuration test failure (redhat)" {
+  stub_path /usr/sbin/td-agent "false"
+
+  run_service configtest
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+}

--- a/bats/reload_debian.bats
+++ b/bats/reload_debian.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "reload td-agent successfully (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service reload
+  assert_output <<EOS
+start-stop-daemon
+  --stop
+  --signal
+  1
+  --quiet
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --name
+  ruby
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to reload td-agent (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "false"
+  stub log_end_msg "1 : false"
+
+  run_service reload
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to reload td-agent by configuration test failure (debian)" {
+  stub_path /usr/sbin/td-agent "false"
+  stub log_end_msg "1 : false"
+
+  run_service reload
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub log_end_msg
+}

--- a/bats/reload_redhat.bats
+++ b/bats/reload_redhat.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "reload td-agent successfully (redhat)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "echo; for arg; do echo \"  \$arg\"; done"
+
+  run_service reload
+  assert_output <<EOS
+Reloading td-agent: 
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  -HUP
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+}
+
+@test "failed to reload td-agent (redhat)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "false"
+
+  run_service reload
+  assert_output <<EOS
+Reloading td-agent: 
+EOS
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+}
+
+@test "failed to reload td-agent by configuration test failure (redhat)" {
+  stub_path /usr/sbin/td-agent "false"
+
+  run_service reload
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+}

--- a/bats/render
+++ b/bats/render
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+
+# load variables from `../config/software/td-agent-files.rb`...?
+root_path = ENV.fetch("TMP", "/")
+install_path = "/opt/td-agent"
+project_name = "td-agent"
+project_name_snake = project_name.gsub("-", "_")
+project_name_snake_upcase = project_name_snake.upcase
+
+require "erb"
+STDOUT.puts(ERB.new(ARGF.read).result())
+
+# vim:set ft=ruby :

--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "restart td-agent successfully (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo stop" \
+                                    "echo stopped successfully" \
+                                    "echo not running" \
+                                    "echo started"
+  stub log_end_msg "0 : true"
+
+  run_service restart
+  assert_output <<EOS
+stop
+stopped successfully
+started
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "restart td-agent regardless of stop failure (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo stop" \
+                                    "echo failed to stop; false" \
+                                    "echo not running" \
+                                    "echo started"
+  stub log_end_msg "0 : true"
+
+  run_service restart
+  assert_output <<EOS
+stop
+failed to stop
+started
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to restart td-agent by configuration test failure (debian)" {
+  stub_path /usr/sbin/td-agent "false"
+  stub log_end_msg "1 : false"
+
+  run_service restart
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub log_end_msg
+}
+
+@test "failed to restart td-agent by stale process (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo stop" \
+                                    "echo stopped successfully" \
+                                    "echo still running; false"
+  stub log_end_msg "1 : false"
+
+  run_service restart
+  assert_output <<EOS
+stop
+stopped successfully
+EOS
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to restart td-agent by start failure (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo stop" \
+                                    "echo stopped successfully" \
+                                    "echo not running" \
+                                    "echo failed to start; false"
+  stub log_end_msg "1 : false"
+
+  run_service restart
+  assert_output <<EOS
+stop
+stopped successfully
+failed to start
+EOS
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}

--- a/bats/restart_redhat.bats
+++ b/bats/restart_redhat.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "restart td-agent successfully (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "true"
+  stub success "true"
+  stub daemon "true"
+
+  run_service restart
+  assert_output <<EOS
+Shutting down td-agent: 
+Starting td-agent: 
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+  unstub success
+  unstub daemon
+}
+
+@test "restart td-agent regardless of stop failure (redhat)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "false"
+  stub failure "false"
+  stub daemon "true"
+
+  run_service restart
+  assert_output <<EOS
+Shutting down td-agent: 
+Starting td-agent: 
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+  unstub failure
+  unstub daemon
+}
+
+@test "failed to restart td-agent by configuration test failure (redhat)" {
+  stub_path /usr/sbin/td-agent "false"
+
+  run_service restart
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
+}
+
+@test "failed to restart td-agent by start failure (redhat)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "true"
+  stub success "true"
+  stub daemon "false"
+
+  run_service restart
+  assert_output <<EOS
+Shutting down td-agent: 
+Starting td-agent: 
+EOS
+  assert_failure
+  [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+  unstub success
+  unstub daemon
+}

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "start td-agent successfully (debian)" {
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service start
+  assert_output <<EOS
+start-stop-daemon
+  --start
+  --quiet
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --exec
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  -c
+  td-agent
+  --group
+  td-agent
+  --
+  ${TMP}/usr/sbin/td-agent
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+EOS
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "start td-agent but it has already been started (debian)" {
+  stub_path /sbin/start-stop-daemon "false"
+  stub log_end_msg "0 : true"
+
+  run_service start
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to start td-agent (debian)" {
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "false"
+  stub log_end_msg "1 : false"
+
+  run_service start
+  assert_failure
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "start td-agent successfully (redhat)" {
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+
+  run_service start
+  assert_output <<EOS
+Starting td-agent: 
+  --pidfile=${TMP}/var/run/td-agent/td-agent.pid
+  --user
+  td-agent
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  ${TMP}/usr/sbin/td-agent --group td-agent --log ${TMP}/var/log/td-agent/td-agent.log --use-v1-config --daemon ${TMP}/var/run/td-agent/td-agent.pid
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub daemon
+}
+
+@test "failed to start td-agent (redhat)" {
+  stub daemon "false"
+
+  run_service start
+  assert_output <<EOS
+Starting td-agent: 
+EOS
+  assert_failure
+  [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub daemon
+}

--- a/bats/status_debian.bats
+++ b/bats/status_debian.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "show td-agent status successfully (debian)" {
+  stub status_of_proc "for arg; do echo \$arg; done"
+
+  run_service status
+  assert_output <<EOS
+${TMP}/opt/td-agent/embedded/bin/ruby
+td-agent
+EOS
+  assert_success
+
+  unstub status_of_proc
+}
+
+@test "failed to show td-agent status (debian)" {
+  stub status_of_proc "false"
+
+  run_service status
+  assert_failure
+
+  unstub status_of_proc
+}

--- a/bats/status_redhat.bats
+++ b/bats/status_redhat.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "show td-agent status successfully (redhat)" {
+  stub status "-p ${TMP}/var/run/td-agent/td-agent.pid td-agent : true"
+
+  run_service status
+  assert_success
+
+  unstub status
+}
+
+@test "failed to show td-agent status (redhat)" {
+  stub status "-p ${TMP}/var/run/td-agent/td-agent.pid td-agent : false"
+
+  run_service status
+  assert_failure
+
+  unstub status
+}

--- a/bats/stop_debian.bats
+++ b/bats/stop_debian.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "stop td-agent successfully (debian)" {
+  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service stop
+  assert_output <<EOS
+start-stop-daemon
+  --stop
+  --quiet
+  --retry=TERM/30/KILL/5
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --name
+  ruby
+start-stop-daemon
+  --stop
+  --quiet
+  --oknodo
+  --retry=0/30/KILL/5
+  --exec
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+EOS
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "stop td-agent but it has already been stopped (debian)" {
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "false"
+  stub log_end_msg "0 : true"
+
+  run_service stop
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to stop td-agent (debian)" {
+  stub_path /sbin/start-stop-daemon "exit 2"
+  stub log_end_msg "1 : false"
+
+  run_service stop
+  assert_failure
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "failed to stop td-agent children processes (debian)" {
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "exit 2"
+  stub log_end_msg "1 : false"
+
+  run_service stop
+  assert_failure
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "stop td-agent successfully (redhat)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub kill "1234 : true" \
+             "-0 1234 : false"
+  stub success "true"
+
+  run_service stop
+  assert_output <<EOS
+Shutting down td-agent: 
+EOS
+  assert_success
+  [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub kill
+  unstub success
+}
+
+@test "stop td-agent but it has already been stopped (redhat)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub kill "1234 : false"
+  stub failure "false"
+
+  run_service stop
+  assert_output <<EOS
+Shutting down td-agent: 
+EOS
+  assert_failure # TODO: change this to success for compatibility between debian
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub kill
+  unstub failure
+}
+
+@test "failed to stop td-agent (redhat)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  cat <<SH > "${TMP}/etc/sysconfig/td-agent"
+STOPTIMEOUT=3
+SH
+
+  stub kill "1234 : true" \
+            "-0 1234 : true" \
+            "-0 1234 : true" \
+            "-0 1234 : true"
+  stub sleep "1 : true"
+  stub failure "false"
+
+  run_service stop
+  assert_output <<EOS
+Shutting down td-agent: Timeout error occurred trying to stop td-agent...
+EOS
+  assert_failure
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub kill
+  unstub failure
+}
+
+@test "stop td-agent by name successfully (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub killproc "td-agent : true"
+  stub success "true"
+
+  run_service stop
+  assert_output <<EOS
+Shutting down td-agent: 
+EOS
+  assert_success
+  [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub killproc
+  unstub success
+}
+
+@test "failed to stop td-agent by name (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub killproc "td-agent : false"
+  stub failure "false"
+
+  run_service stop
+  assert_output <<EOS
+Shutting down td-agent: 
+EOS
+  assert_failure
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub killproc
+  unstub failure
+}

--- a/bats/stubs/stub
+++ b/bats/stubs/stub
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -e
+
+status=0
+program="${0##*/}"
+PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
+[ -n "$TMPDIR" ] || TMPDIR="/tmp"
+
+_STUB_PLAN="${PROGRAM}_STUB_PLAN"
+_STUB_RUN="${PROGRAM}_STUB_RUN"
+_STUB_INDEX="${PROGRAM}_STUB_INDEX"
+_STUB_RESULT="${PROGRAM}_STUB_RESULT"
+_STUB_END="${PROGRAM}_STUB_END"
+_STUB_DEBUG="${PROGRAM}_STUB_DEBUG"
+
+if [ -n "${!_STUB_DEBUG}" ]; then
+  echo "$program" "$@" >&${!_STUB_DEBUG}
+fi
+
+[ -e "${!_STUB_PLAN}" ] || exit 1
+[ -n "${!_STUB_RUN}" ] || eval "${_STUB_RUN}"="${TMPDIR}/${program}-stub-run"
+
+
+# Initialize or load the stub run information.
+eval "${_STUB_INDEX}"=1
+eval "${_STUB_RESULT}"=0
+[ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
+
+
+# Loop over each line in the plan.
+index=0
+while IFS= read -r line; do
+  index=$(($index + 1))
+
+  if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
+    # We found the plan line we're interested in.
+    # Start off by assuming success.
+    result=0
+
+    # Split the line into an array of arguments to
+    # match and a command to run to produce output.
+    command=" $line"
+    if [ "$command" != "${command/ : }" ]; then
+      patterns="${command%% : *}"
+      command="${command#* : }"
+    fi
+
+    # Naively split patterns by whitespace for now.
+    # In the future, use a sed script to split while
+    # respecting quoting.
+    set -f
+    patterns=($patterns)
+    set +f
+    arguments=("$@")
+
+    # Match the expected argument patterns to actual
+    # arguments.
+    for (( i=0; i<${#patterns[@]}; i++ )); do
+      pattern="${patterns[$i]}"
+      argument="${arguments[$i]}"
+
+      case "$argument" in
+        $pattern ) ;;
+        * ) result=1 ;;
+      esac
+    done
+
+    # If the arguments matched, evaluate the command
+    # in a subshell. Otherwise, log the failure.
+    if [ $result -eq 0 ] ; then
+      set +e
+      ( eval "$command" )
+      status="$?"
+      set -e
+    else
+      eval "${_STUB_RESULT}"=1
+    fi
+  fi
+done < "${!_STUB_PLAN}"
+
+
+if [ -n "${!_STUB_END}" ]; then
+  # Clean up the run file.
+  rm -f "${!_STUB_RUN}"
+
+  # If the number of lines in the plan is larger than
+  # the requested index, we failed.
+  if [ $index -ge "${!_STUB_INDEX}" ]; then
+    eval "${_STUB_RESULT}"=1
+  fi
+
+  # Return the result.
+  exit "${!_STUB_RESULT}"
+
+else
+  # If the requested index is larger than the number
+  # of lines in the plan file, we failed.
+  if [ "${!_STUB_INDEX}" -gt $index ]; then
+    eval "${_STUB_RESULT}"=1
+  fi
+
+  # Write out the run information.
+  { echo "${_STUB_INDEX}=$((${!_STUB_INDEX} + 1))"
+    echo "${_STUB_RESULT}=${!_STUB_RESULT}"
+  } > "${!_STUB_RUN}"
+
+  exit "$status"
+
+fi

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -1,0 +1,193 @@
+export TMP="${BATS_TEST_DIRNAME}/tmp"
+
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
+PATH="${TMP}/bin:${PATH}"
+export PATH
+
+init_debian() {
+  mkdir -p "${TMP}/bin"
+
+  mkdir -p "${TMP}/etc/default"
+
+  mkdir -p "${TMP}/etc/init.d"
+  "${BATS_TEST_DIRNAME}/render" "${BATS_TEST_DIRNAME}/../templates/etc/init.d/deb/td-agent" > "${TMP}/etc/init.d/td-agent"
+  chmod +x "${TMP}/etc/init.d/td-agent"
+
+  mkdir -p "${TMP}/lib/lsb"
+  touch "${TMP}/lib/lsb/init-functions"
+
+  mkdir -p "${TMP}/sbin"
+
+  mkdir -p "${TMP}/usr/bin"
+
+  mkdir -p "${TMP}/usr/sbin"
+  touch "${TMP}/usr/sbin/td-agent"
+  chmod +x "${TMP}/usr/sbin/td-agent"
+
+  mkdir -p "${TMP}/opt/td-agent/embedded/bin"
+  touch "${TMP}/opt/td-agent/embedded/bin/ruby"
+  chmod +x "${TMP}/opt/td-agent/embedded/bin/ruby"
+
+  mkdir -p "${TMP}/opt/td-agent/embedded/lib"
+
+  mkdir -p "${TMP}/var/log/td-agent"
+
+  mkdir -p "${TMP}/var/run/td-agent"
+}
+
+stub_debian() {
+  stub getent "passwd : echo td-agent:x:500:500:,,,:/var/lib/td-agent:/sbin/nologin"
+  stub chown true
+  stub getent "group : echo td-agent:x:500:"
+  stub log_daemon_msg true
+}
+
+unstub_debian() {
+  unstub getent
+  unstub chown
+  unstub log_daemon_msg
+}
+
+init_redhat() {
+  mkdir -p "${TMP}/bin"
+
+  mkdir -p "${TMP}/etc/init.d"
+  touch "${TMP}/etc/init.d/functions"
+
+  mkdir -p "${TMP}/etc/init.d"
+  "${BATS_TEST_DIRNAME}/render" "${BATS_TEST_DIRNAME}/../templates/etc/init.d/rpm/td-agent" > "${TMP}/etc/init.d/td-agent"
+  chmod +x "${TMP}/etc/init.d/td-agent"
+
+  mkdir -p "${TMP}/etc/sysconfig"
+
+  mkdir -p "${TMP}/sbin"
+
+  mkdir -p "${TMP}/usr/bin"
+
+  mkdir -p "${TMP}/usr/sbin"
+  touch "${TMP}/usr/sbin/td-agent"
+  chmod +x "${TMP}/usr/sbin/td-agent"
+
+  mkdir -p "${TMP}/opt/td-agent/embedded/bin"
+  touch "${TMP}/opt/td-agent/embedded/bin/ruby"
+  chmod +x "${TMP}/opt/td-agent/embedded/bin/ruby"
+
+  mkdir -p "${TMP}/opt/td-agent/embedded/lib"
+
+  mkdir -p "${TMP}/var/lock/subsys"
+
+  mkdir -p "${TMP}/var/log/td-agent"
+
+  mkdir -p "${TMP}/var/run/td-agent"
+}
+
+stub_redhat() {
+  stub chown true
+}
+
+unstub_redhat() {
+  unstub chown
+}
+
+teardown() {
+  rm -fr "${TMP}"/*
+}
+
+stub() {
+  local program="$1"
+  local prefix="$(echo "$program" | tr a-z- A-Z_)"
+  shift
+
+  export "${prefix}_STUB_PLAN"="${TMP}/${program}-stub-plan"
+  export "${prefix}_STUB_RUN"="${TMP}/${program}-stub-run"
+  export "${prefix}_STUB_END"=
+
+  mkdir -p "${TMP}/bin"
+  ln -sf "${BATS_TEST_DIRNAME}/stubs/stub" "${TMP}/bin/${program}"
+
+  touch "${TMP}/${program}-stub-plan"
+  for arg in "$@"; do printf "%s\n" "$arg" >> "${TMP}/${program}-stub-plan"; done
+}
+
+unstub() {
+  local program="$1"
+  local prefix="$(echo "$program" | tr a-z- A-Z_)"
+  local path="${TMP}/bin/${program}"
+
+  export "${prefix}_STUB_END"=1
+
+  local STATUS=0
+  "$path" || STATUS="$?"
+
+  rm -f "$path"
+  rm -f "${TMP}/${program}-stub-plan" "${TMP}/${program}-stub-run"
+  return "$STATUS"
+}
+
+stub_path() {
+  local path="$1"
+  local name="${path##*/}"
+  shift 1
+  stub "${name}" "$@"
+  mv -f "${TMP}/bin/${name}" "${TMP}/${path#/}"
+}
+
+unstub_path() {
+  local path="$1"
+  local name="${path##*/}"
+  shift 1
+  mv -f "${TMP}/${path#/}" "${TMP}/bin/${name}"
+  unstub "${name}"
+}
+
+assert() {
+  if ! "$@"; then
+    flunk "failed: $@"
+  fi
+}
+
+flunk() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "$@"
+    fi
+  } | sed "s:${TMP}:\${TMP}:g" >&2
+  return 1
+}
+
+assert_success() {
+  if [ "$status" -ne 0 ]; then
+    { echo "command failed with exit status $status"
+      echo "output: $output"
+    } | flunk
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_failure() {
+  if [ "$status" -eq 0 ]; then
+    flunk "expected failed exit status"
+  elif [ "$#" -gt 0 ]; then
+    assert_output "$1"
+  fi
+}
+
+assert_equal() {
+  if [ "$1" != "$2" ]; then
+    { echo "expected: $1"
+      echo "actual:   $2"
+    } | flunk
+  fi
+}
+
+assert_output() {
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal "$expected" "$output"
+}
+
+run_service() {
+  run "${TMP}/etc/init.d/td-agent" "$@"
+}

--- a/config/software/td-agent-files.rb
+++ b/config/software/td-agent-files.rb
@@ -10,6 +10,7 @@ build do
   block do
     # setup related files
     pkg_type = project.packager.id.to_s
+    root_path = "/" # for ERB
     install_path = project.install_dir # for ERB
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -160,7 +160,8 @@ case "$1" in
 	# and leave 'force-reload' as an alias for 'restart'.
 	#
 	log_daemon_msg "Reloading $DESC" "$NAME"
-  do_configtest && do_reload || RETVAL="$?"
+	do_configtest || log_end_msg 1
+	do_reload || RETVAL="$?"
 	log_end_msg "$RETVAL"
 	;;
   restart|force-reload)
@@ -169,7 +170,8 @@ case "$1" in
 	# 'force-reload' alias
 	#
 	log_daemon_msg "Restarting $DESC" "$NAME"
-	do_configtest && do_stop || RETVAL="$?"
+	do_configtest || log_end_msg 1
+	do_stop || RETVAL="$?"
 	case "$RETVAL" in
 	  0|1)
 		RETVAL=0

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -16,30 +16,30 @@ set -e
 NAME=<%= project_name %>
 
 # Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+[ -r <%= File.join(root_path, "etc/default/$NAME") %> ] && . <%= File.join(root_path, "etc/default/$NAME") %>
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH=<%= "/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":") %>
 USER=<%= project_name %>                   # Running user
 GROUP=<%= project_name %>                  # Running group
 DESC=<%= project_name %>                   # Introduce a short description here
-PIDFILE=/var/run/$NAME/$NAME.pid
-DAEMON=<%= install_path %>/embedded/bin/ruby # Introduce the server's location here
+PIDFILE=<%= File.join(root_path, "var/run/$NAME/$NAME.pid") %>
+DAEMON=<%= File.join(root_path, install_path, "embedded/bin/ruby") %> # Introduce the server's location here
 # Arguments to run the daemon with
-DAEMON_ARGS="/usr/sbin/<%= project_name %> $DAEMON_ARGS --daemon $PIDFILE --log /var/log/<%= project_name %>/<%= project_name %>.log --use-v1-config"
-SCRIPTNAME=/etc/init.d/$NAME
+DAEMON_ARGS="<%= File.join(root_path, "usr/sbin", project_name) %> $DAEMON_ARGS --daemon $PIDFILE --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config"
+SCRIPTNAME=<%= File.join(root_path, "etc/init.d/$NAME") %>
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
 
 # Load the VERBOSE setting and other rcS variables
-# . /lib/init/vars.sh
+# . <%= File.join(root_path, "lib/init/vars.sh") %>
 VERBOSE="yes"
 
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
-. /lib/lsb/init-functions
+. <%= File.join(root_path, "lib/lsb/init-functions") %>
 
 # Check the user
 if [ -n "${USER}" ]; then
@@ -63,8 +63,8 @@ fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # Use jemalloc to avoid memory fragmentation
-if [ -f "<%= install_path %>/embedded/lib/libjemalloc.so" ]; then
-	export LD_PRELOAD=<%= install_path %>/embedded/lib/libjemalloc.so
+if [ -f "<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>" ]; then
+	export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
 fi
 
 #

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -77,7 +77,7 @@ do_stop() {
 		    while [ $TIMEOUT -gt 0 ]; do
 			<%= File.join(root_path, "bin/kill") %> -0 "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || break
 			sleep 1
-			let TIMEOUT=${TIMEOUT}-1
+			let TIMEOUT=${TIMEOUT}-1 || true
 		    done
 		    if [ $TIMEOUT -eq 0 ]; then
 			echo -n "Timeout error occurred trying to stop <%= project_name %>..."

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# /etc/rc.d/init.d/<%= project_name %>
+# <%= File.join(root_path, "etc/rc.d/init.d", project_name) %>
 #
 # chkconfig: - 80 20
 # description: <%= project_name %>
 # processname: <%= project_name %>
-# pidfile: /var/run/<%= project_name %>/<%= project_name %>.pid
+# pidfile: <%= File.join(root_path, "var/run", project_name, "#{project_name}.pid") %>
 #
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
@@ -17,23 +17,23 @@
 ### END INIT INFO
 
 # Source function library.
-. /etc/init.d/functions
+. <%= File.join(root_path, "etc/init.d/functions") %>
 
 set -e
 
 name="<%= project_name %>"
 prog="<%= project_name %>"
-process_bin=<%= install_path %>/embedded/bin/ruby
+process_bin=<%= File.join(root_path, install_path, "embedded/bin/ruby") %>
 
-# timeout can be overridden from /etc/sysconfig/<%= project_name %>
+# timeout can be overridden from <%= File.join(root_path, "etc/sysconfig", project_name) %>
 STOPTIMEOUT=120
 
-if [ -f /etc/sysconfig/$prog ]; then
-	. /etc/sysconfig/$prog
+if [ -f <%= File.join(root_path, "etc/sysconfig/$prog") %> ]; then
+	. <%= File.join(root_path, "etc/sysconfig/$prog") %>
 fi
-PIDFILE=${PIDFILE-/var/run/<%= project_name %>/$prog.pid}
+PIDFILE=${PIDFILE-<%= File.join(root_path, "var/run", project_name, "$prog.pid") %>}
 DAEMON_ARGS=${DAEMON_ARGS---user <%= project_name %>}
-<%= project_name_snake_upcase %>_ARGS="${<%= project_name_snake_upcase %>_ARGS-/usr/sbin/<%= project_name %> --group <%= project_name %> --log /var/log/<%= project_name %>/<%= project_name %>.log --use-v1-config}"
+<%= project_name_snake_upcase %>_ARGS="${<%= project_name_snake_upcase %>_ARGS-<%= File.join(root_path, "usr/sbin", project_name) %> --group <%= project_name %> --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
 	PIDFILE_DIR=$(dirname ${PIDFILE})
@@ -46,8 +46,8 @@ fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # use jemalloc to avoid fragmentation
-if [ -f "<%= install_path %>/embedded/lib/libjemalloc.so" ]; then
-        export LD_PRELOAD=<%= install_path %>/embedded/lib/libjemalloc.so
+if [ -f "<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>" ]; then
+        export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
 fi
 
 RETVAL=0
@@ -60,7 +60,7 @@ do_start() {
 	local RETVAL=0
 	daemon --pidfile=$PIDFILE $DAEMON_ARGS $process_bin "$<%= project_name_snake_upcase %>_ARGS" || RETVAL="$?"
 	echo
-	[ $RETVAL -eq 0 ] && touch /var/lock/subsys/$prog
+	[ $RETVAL -eq 0 ] && touch <%= File.join(root_path, "var/lock/subsys/$prog") %>
 	return $RETVAL
 }
 
@@ -71,11 +71,11 @@ do_stop() {
 	    # Use own process termination instead of killproc because killproc can't wait SIGTERM
 	    <%= project_name_snake_upcase %>_PID=`cat "$PIDFILE" 2>/dev/null`
 	    if [ -n "$<%= project_name_snake_upcase %>_PID" ]; then
-		/bin/kill "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || RETVAL="$?"
+		<%= File.join(root_path, "bin/kill") %> "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || RETVAL="$?"
 		if [ $RETVAL -eq 0 ]; then
 		    TIMEOUT="$STOPTIMEOUT"
 		    while [ $TIMEOUT -gt 0 ]; do
-			/bin/kill -0 "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || break
+			<%= File.join(root_path, "bin/kill") %> -0 "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || break
 			sleep 1
 			let TIMEOUT=${TIMEOUT}-1
 		    done
@@ -103,7 +103,7 @@ do_stop() {
 	    fi
 	fi
 	echo
-	[ $RETVAL -eq 0 ] && rm -f $PIDFILE && rm -f /var/lock/subsys/$prog
+	[ $RETVAL -eq 0 ] && rm -f $PIDFILE && rm -f <%= File.join(root_path, "var/lock/subsys/$prog") %>
 	return $RETVAL
 }
 
@@ -140,7 +140,7 @@ case "$1" in
 	do_reload
 	;;
     condrestart)
-	[ -f /var/lock/subsys/$prog ] && do_restart || :
+	[ -f <%= File.join(root_path, "var/lock/subsys/$prog") %> ] && do_restart || :
 	;;
     configtest)
         do_configtest

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -109,7 +109,7 @@ do_stop() {
 
 do_restart() {
 	do_configtest || return $?
-	do_stop
+	do_stop || true
 	do_start
 }
 

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -82,16 +82,16 @@ do_stop() {
 		    if [ $TIMEOUT -eq 0 ]; then
 			echo -n "Timeout error occurred trying to stop <%= project_name %>..."
 			RETVAL=1
-			failure
+			failure || true
 		    else
 			RETVAL=0
 			success
 		    fi
 		else
-		    failure
+		    failure || true
 		fi
 	    else
-		failure
+		failure || true
 		RETVAL=4
 	    fi
 	else
@@ -99,7 +99,7 @@ do_stop() {
 	    if [ $RETVAL -eq 0 ]; then
 		success
 	    else
-		failure
+		failure || true
 	    fi
 	fi
 	echo


### PR DESCRIPTION
There should be tests even for init scripts. I wrote tests with using https://github.com/sstephenson/bats . Test coverage is still not so good, but I believe it's sufficient for starter.

I also fixed unintended init script behaviour (==> bugs) found during testing. I believe this should solve the problems of init script like #42 .

1. Added a new template variable `root_path`
1. Added guard for potential problem found in RedHat's init functions (92f9cde286bf506f0496ce4b154c16faa7976108, 3714daead5e3a09767847f4bcea108d06b6245f9)
1. The `restart` action should fail immediately if `configtest` failed (dd63b6e05f46b72d17063ffdfc493a0ea9f22f77)
1. The `restart` action should not fail immediately on `do_stop` failure since it might mean the old process has already been stopped (09983caed1b6f327d374d0c031f6e8f9cf151e06)

@repeatedly Can you review the changes from the point of view of Omnibus configuration.