### PR TITLE
Extra bats tests, including configurable td-agent arguments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ resources/td-agent/etc/init.d/td-agent
 
 # bats
 /bats/bats
+/bats/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-language: ruby
-rvm:
-  - 2.1.6
-script: bundle exec rake bats:all
+language: c
+install: git clone --depth 1 https://github.com/sstephenson/bats.git bats/bats
+script: bats/bats/bin/bats --tap bats

--- a/Rakefile
+++ b/Rakefile
@@ -23,22 +23,3 @@ namespace :spec do
     end
   end
 end
-
-namespace :bats do
-  bats_path = File.expand_path("../bats/bats", __FILE__)
-  test_path = File.expand_path("../bats", __FILE__)
-
-  desc "Run bats tests for init scripts"
-  task :all => [:setup, :run]
-  task :default => :all
-
-  task :setup do
-    unless File.exist?(bats_path)
-      sh "git clone https://github.com/sstephenson/bats.git #{Shellwords.shellescape(bats_path)}"
-    end
-  end
-
-  task :run do
-    sh "#{Shellwords.shellescape(File.join(bats_path, "bin", "bats"))} --tap #{Shellwords.shellescape(test_path)}"
-  end
-end

--- a/bats/compat_debian.bats
+++ b/bats/compat_debian.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "start td-agent with backward-compatibile configuration (debian)" {
+  cat <<EOS > "${TMP}/etc/default/td-agent"
+NAME="custom_name"
+EOS
+
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service start
+  assert_output <<EOS
+Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
+start-stop-daemon
+  --start
+  --quiet
+  --pidfile
+  ${TMP}/var/run/custom_name/custom_name.pid
+  --exec
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  -c
+  td-agent
+  --group
+  td-agent
+  --
+  ${TMP}/usr/sbin/td-agent
+  --daemon
+  ${TMP}/var/run/custom_name/custom_name.pid
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+EOS
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}

--- a/bats/compat_redhat.bats
+++ b/bats/compat_redhat.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "start td-agent with backward-compatible configuration (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
+  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
+name="custom_name"
+process_bin="${TMP}/path/to/custom_process_bin"
+prog="custom_prog"
+EOS
+
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+
+  run_service start
+  assert_output <<EOS
+Warning: Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_NAME instead.
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
+Warning: Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_RUBY instead.
+Starting custom_name: 
+  --pidfile=${TMP}/var/run/td-agent/custom_prog.pid
+  --user
+  td-agent
+  ${TMP}/path/to/custom_process_bin
+  ${TMP}/usr/sbin/td-agent
+  --group
+  td-agent
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/custom_prog.pid
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/custom_prog" ]
+
+  unstub daemon
+}
+
+@test "stop td-agent with backward-compatible configuration (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
+  touch "${TMP}/var/lock/subsys/custom_prog"
+  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
+prog="custom_prog"
+EOS
+
+  stub killproc "custom_prog : true"
+  stub success "true"
+
+  run_service stop
+  assert_output <<EOS
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
+Shutting down td-agent: 
+EOS
+  assert_success
+  [ ! -f "${TMP}/var/lock/subsys/custom_prog" ]
+
+  unstub killproc
+  unstub success
+}

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+}
+
+teardown() {
+  rm -fr "${TMP}"/*
+}
+
+custom_run() {
+  stub log_end_msg "0 : true"
+  cat > "${TMP}/etc/default/td-agent"
+  run_service "${1:-start}"
+  assert_success
+  unstub log_end_msg
+}
+
+@test "start td-agent with additional arguments successfully (debian)" {
+  stub_debian
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  custom_run <<EOS
+DAEMON_ARGS="--verbose --verbose"
+EOS
+  assert_output <<EOS
+start-stop-daemon
+  --start
+  --quiet
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --exec
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  -c
+  td-agent
+  --group
+  td-agent
+  --
+  ${TMP}/usr/sbin/td-agent
+  --verbose
+  --verbose
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+EOS
+  unstub_path /sbin/start-stop-daemon
+}
+
+@test "start td-agent with custom configurations successfully (debian)" {
+  stub getent "passwd : echo custom_td_agent_user:x:501:501:,,,:/var/lib/custom_td_agent_user:/sbin/nologin"
+  stub chown true
+  stub getent "group : echo custom_td_agent_group:x:501:"
+  stub log_daemon_msg true
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  mkdir -p "${TMP}/path/to"
+  touch "${TMP}/path/to/custom_td_agent_ruby"
+  chmod +x "${TMP}/path/to/custom_td_agent_ruby"
+  custom_run <<EOS
+TD_AGENT_NAME="custom_td_agent_name"
+TD_AGENT_HOME="${TMP}/path/to/custom_td_agent_home"
+TD_AGENT_DEFAULT="${TMP}/path/to/custom_td_agent_default"
+TD_AGENT_USER="custom_td_agent_user"
+TD_AGENT_GROUP="custom_td_agent_group"
+TD_AGENT_RUBY="${TMP}/path/to/custom_td_agent_ruby"
+TD_AGENT_BIN_FILE="${TMP}/path/to/custom_td_agent_bin_file"
+TD_AGENT_LOG_FILE="${TMP}/path/to/custom_td_agent_log_file"
+TD_AGENT_PID_FILE="${TMP}/path/to/custom_td_agent_pid_file"
+EOS
+  assert_output <<EOS
+start-stop-daemon
+  --start
+  --quiet
+  --pidfile
+  ${TMP}/path/to/custom_td_agent_pid_file
+  --exec
+  ${TMP}/path/to/custom_td_agent_ruby
+  -c
+  custom_td_agent_user
+  --group
+  custom_td_agent_group
+  --
+  ${TMP}/path/to/custom_td_agent_bin_file
+  --daemon
+  ${TMP}/path/to/custom_td_agent_pid_file
+  --log
+  ${TMP}/path/to/custom_td_agent_log_file
+  --use-v1-config
+EOS
+  unstub_path /sbin/start-stop-daemon
+  unstub getent
+  unstub chown
+  unstub log_daemon_msg
+}

--- a/bats/override_redhat.bats
+++ b/bats/override_redhat.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+custom_run() {
+  cat > "${TMP}/etc/sysconfig/td-agent"
+  run_service "${1:-start}"
+  assert_success
+}
+
+@test "start td-agent with custom arguments successfully (redhat)" {
+  rm -f "${TMP}/path/to/td-agent.pid"
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+  custom_run <<EOS
+DAEMON_ARGS="--user nobody"
+PIDFILE="${TMP}/path/to/td-agent.pid"
+TD_AGENT_ARGS="/path/to/td-agent --verbose --verbose --group nogroup --log /path/to/td-agent.log"
+EOS
+  assert_output <<EOS
+Starting td-agent: 
+  --pidfile=${TMP}/path/to/td-agent.pid
+  --user
+  nobody
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  /path/to/td-agent
+  --verbose
+  --verbose
+  --group
+  nogroup
+  --log
+  /path/to/td-agent.log
+  --daemon
+  ${TMP}/path/to/td-agent.pid
+EOS
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+}
+
+@test "start td-agent with custom configurations successfully (redhat)" {
+  rm -f "${TMP}/path/to/td-agent.pid"
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+  custom_run <<EOS
+TD_AGENT_NAME="custom_td_agent_name"
+TD_AGENT_HOME="${TMP}/path/to/custom_td_agent_home"
+TD_AGENT_DEFAULT="${TMP}/path/to/custom_td_agent_default"
+TD_AGENT_USER="custom_td_agent_user"
+TD_AGENT_GROUP="custom_td_agent_group"
+TD_AGENT_RUBY="${TMP}/path/to/custom_td_agent_ruby"
+TD_AGENT_BIN_FILE="${TMP}/path/to/custom_td_agent_bin_file"
+TD_AGENT_LOG_FILE="${TMP}/path/to/custom_td_agent_log_file"
+TD_AGENT_PID_FILE="${TMP}/path/to/custom_td_agent_pid_file"
+TD_AGENT_LOCK_FILE="${TMP}/path/to/custom_td_agent_lock_file"
+EOS
+  assert_output <<EOS
+Starting custom_td_agent_name: 
+  --pidfile=${TMP}/path/to/custom_td_agent_pid_file
+  --user
+  custom_td_agent_user
+  ${TMP}/path/to/custom_td_agent_ruby
+  ${TMP}/path/to/custom_td_agent_bin_file
+  --group
+  custom_td_agent_group
+  --log
+  ${TMP}/path/to/custom_td_agent_log_file
+  --use-v1-config
+  --daemon
+  ${TMP}/path/to/custom_td_agent_pid_file
+EOS
+  [ -f "${TMP}/path/to/custom_td_agent_lock_file" ]
+}

--- a/bats/reload_debian.bats
+++ b/bats/reload_debian.bats
@@ -36,6 +36,30 @@ EOS
   unstub log_end_msg
 }
 
+@test "reload td-agent forcibly (debian)" {
+  stub_path /usr/sbin/td-agent "true"
+  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service force-reload
+  assert_output <<EOS
+start-stop-daemon
+  --stop
+  --signal
+  1
+  --quiet
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --name
+  ruby
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
 @test "failed to reload td-agent (debian)" {
   stub_path /usr/sbin/td-agent "true"
   stub_path /sbin/start-stop-daemon "false"

--- a/bats/restart_redhat.bats
+++ b/bats/restart_redhat.bats
@@ -82,3 +82,35 @@ EOS
   unstub success
   unstub daemon
 }
+
+@test "conditional restart of td-agent (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub_path /usr/sbin/td-agent "true"
+  stub killproc "true"
+  stub success "true"
+  stub daemon "true"
+
+  run_service condrestart
+  assert_output <<EOS
+Shutting down td-agent: 
+Starting td-agent: 
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub_path /usr/sbin/td-agent
+  unstub killproc
+  unstub success
+  unstub daemon
+}
+
+@test "conditional restart do nothing if lock file doesn't exist (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  rm -f "${TMP}/var/lock/subsys/td-agent"
+
+  run_service condrestart
+  assert_success
+  [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
+}

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -46,43 +46,6 @@ EOS
   unstub log_end_msg
 }
 
-@test "start td-agent with custom configuration successfully (debian)" {
-  cat <<EOS > "${TMP}/etc/default/td-agent"
-DAEMON_ARGS="-vv"
-EOS
-
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
-  stub log_end_msg "0 : true"
-
-  run_service start
-  assert_output <<EOS
-start-stop-daemon
-  --start
-  --quiet
-  --pidfile
-  ${TMP}/var/run/td-agent/td-agent.pid
-  --exec
-  ${TMP}/opt/td-agent/embedded/bin/ruby
-  -c
-  td-agent
-  --group
-  td-agent
-  --
-  ${TMP}/usr/sbin/td-agent
-  -vv
-  --daemon
-  ${TMP}/var/run/td-agent/td-agent.pid
-  --log
-  ${TMP}/var/log/td-agent/td-agent.log
-  --use-v1-config
-EOS
-  assert_success
-
-  unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
-}
-
 @test "start td-agent but it has already been started (debian)" {
   stub_path /sbin/start-stop-daemon "false"
   stub log_end_msg "0 : true"

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -49,7 +49,6 @@ EOS
 @test "start td-agent with custom configuration successfully (debian)" {
   cat <<EOS > "${TMP}/etc/default/td-agent"
 DAEMON_ARGS="-vv"
-NAME="custom_name"
 EOS
 
   stub_path /sbin/start-stop-daemon "true" \
@@ -58,12 +57,11 @@ EOS
 
   run_service start
   assert_output <<EOS
-Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
 start-stop-daemon
   --start
   --quiet
   --pidfile
-  ${TMP}/var/run/custom_name/custom_name.pid
+  ${TMP}/var/run/td-agent/td-agent.pid
   --exec
   ${TMP}/opt/td-agent/embedded/bin/ruby
   -c
@@ -74,7 +72,7 @@ start-stop-daemon
   ${TMP}/usr/sbin/td-agent
   -vv
   --daemon
-  ${TMP}/var/run/custom_name/custom_name.pid
+  ${TMP}/var/run/td-agent/td-agent.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -58,7 +58,7 @@ EOS
 
   run_service start
   assert_output <<EOS
-Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
 start-stop-daemon
   --start
   --quiet

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -49,6 +49,7 @@ EOS
 @test "start td-agent with custom configuration successfully (debian)" {
   cat <<EOS > "${TMP}/etc/default/td-agent"
 DAEMON_ARGS="-vv"
+NAME="custom_name"
 EOS
 
   stub_path /sbin/start-stop-daemon "true" \
@@ -57,11 +58,12 @@ EOS
 
   run_service start
   assert_output <<EOS
+Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
 start-stop-daemon
   --start
   --quiet
   --pidfile
-  ${TMP}/var/run/td-agent/td-agent.pid
+  ${TMP}/var/run/custom_name/custom_name.pid
   --exec
   ${TMP}/opt/td-agent/embedded/bin/ruby
   -c
@@ -72,7 +74,7 @@ start-stop-daemon
   ${TMP}/usr/sbin/td-agent
   -vv
   --daemon
-  ${TMP}/var/run/td-agent/td-agent.pid
+  ${TMP}/var/run/custom_name/custom_name.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -13,6 +13,8 @@ teardown() {
 }
 
 @test "start td-agent successfully (debian)" {
+  rm -f "${TMP}/etc/default/td-agent"
+
   stub_path /sbin/start-stop-daemon "true" \
                                     "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_end_msg "0 : true"
@@ -32,6 +34,43 @@ start-stop-daemon
   td-agent
   --
   ${TMP}/usr/sbin/td-agent
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+EOS
+  assert_success
+
+  unstub_path /sbin/start-stop-daemon
+  unstub log_end_msg
+}
+
+@test "start td-agent with custom configuration successfully (debian)" {
+  cat <<EOS > "${TMP}/etc/default/td-agent"
+DAEMON_ARGS="-vv"
+EOS
+
+  stub_path /sbin/start-stop-daemon "true" \
+                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_end_msg "0 : true"
+
+  run_service start
+  assert_output <<EOS
+start-stop-daemon
+  --start
+  --quiet
+  --pidfile
+  ${TMP}/var/run/td-agent/td-agent.pid
+  --exec
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  -c
+  td-agent
+  --group
+  td-agent
+  --
+  ${TMP}/usr/sbin/td-agent
+  -vv
   --daemon
   ${TMP}/var/run/td-agent/td-agent.pid
   --log

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -58,7 +58,7 @@ EOS
 
   run_service start
   assert_output <<EOS
-Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
 start-stop-daemon
   --start
   --quiet

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -51,9 +51,9 @@ EOS
 
   run_service start
   assert_output <<EOS
-Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_NAME instead.
-Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
-Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_RUBY instead.
+Warning: Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_NAME instead.
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Warning: Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_RUBY instead.
 Starting custom_name: 
   --pidfile=${TMP}/var/run/td-agent/custom_prog.pid
   --user

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -39,38 +39,6 @@ EOS
   unstub daemon
 }
 
-@test "start td-agent with custom configuration successfully (redhat)" {
-  rm -f "${TMP}/path/to/td-agent.pid"
-  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
-DAEMON_ARGS="--user nobody"
-PIDFILE="${TMP}/path/to/td-agent.pid"
-TD_AGENT_ARGS="/path/to/td-agent -vv --group nogroup --log /path/to/td-agent.log"
-EOS
-
-  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
-
-  run_service start
-  assert_output <<EOS
-Starting td-agent: 
-  --pidfile=${TMP}/path/to/td-agent.pid
-  --user
-  nobody
-  ${TMP}/opt/td-agent/embedded/bin/ruby
-  /path/to/td-agent
-  -vv
-  --group
-  nogroup
-  --log
-  /path/to/td-agent.log
-  --daemon
-  ${TMP}/path/to/td-agent.pid
-EOS
-  assert_success
-  [ -f "${TMP}/var/lock/subsys/td-agent" ]
-
-  unstub daemon
-}
-
 @test "failed to start td-agent (redhat)" {
   stub daemon "false"
 

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -39,41 +39,6 @@ EOS
   unstub daemon
 }
 
-@test "start td-agent with custom name successfully (redhat)" {
-  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
-  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
-name="custom_name"
-process_bin="${TMP}/path/to/custom_process_bin"
-prog="custom_prog"
-EOS
-
-  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
-
-  run_service start
-  assert_output <<EOS
-Warning: Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_NAME instead.
-Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
-Warning: Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_RUBY instead.
-Starting custom_name: 
-  --pidfile=${TMP}/var/run/td-agent/custom_prog.pid
-  --user
-  td-agent
-  ${TMP}/path/to/custom_process_bin
-  ${TMP}/usr/sbin/td-agent
-  --group
-  td-agent
-  --log
-  ${TMP}/var/log/td-agent/td-agent.log
-  --use-v1-config
-  --daemon
-  ${TMP}/var/run/td-agent/custom_prog.pid
-EOS
-  assert_success
-  [ -f "${TMP}/var/lock/subsys/custom_prog" ]
-
-  unstub daemon
-}
-
 @test "start td-agent with custom configuration successfully (redhat)" {
   rm -f "${TMP}/path/to/td-agent.pid"
   cat <<EOS > "${TMP}/etc/sysconfig/td-agent"

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -51,9 +51,9 @@ EOS
 
   run_service start
   assert_output <<EOS
-Warning: Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_NAME instead.
-Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
-Warning: Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_RUBY instead.
+Warning: Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_NAME instead.
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
+Warning: Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_RUBY instead.
 Starting custom_name: 
   --pidfile=${TMP}/var/run/td-agent/custom_prog.pid
   --user

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -32,6 +32,34 @@ EOS
   unstub daemon
 }
 
+@test "start td-agent with custom name successfully (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
+  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
+name="custom_name"
+process_bin="${TMP}/path/to/custom_process_bin"
+prog="custom_prog"
+EOS
+
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+
+  run_service start
+  assert_output <<EOS
+Declaring \$name in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_NAME instead.
+Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Declaring \$process_bin in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$AGENT_RUBY instead.
+Starting custom_name: 
+  --pidfile=${TMP}/var/run/td-agent/custom_prog.pid
+  --user
+  td-agent
+  ${TMP}/path/to/custom_process_bin
+  ${TMP}/usr/sbin/td-agent --group td-agent --log ${TMP}/var/log/td-agent/td-agent.log --use-v1-config --daemon ${TMP}/var/run/td-agent/custom_prog.pid
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/custom_prog" ]
+
+  unstub daemon
+}
+
 @test "start td-agent with custom configuration successfully (redhat)" {
   rm -f "${TMP}/path/to/td-agent.pid"
   cat <<EOS > "${TMP}/etc/sysconfig/td-agent"

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -13,6 +13,8 @@ teardown() {
 }
 
 @test "start td-agent successfully (redhat)" {
+  rm -f "${TMP}/etc/sysconfig/td-agent"
+
   stub daemon "echo; for arg; do echo \"  \$arg\"; done"
 
   run_service start
@@ -23,6 +25,31 @@ Starting td-agent:
   td-agent
   ${TMP}/opt/td-agent/embedded/bin/ruby
   ${TMP}/usr/sbin/td-agent --group td-agent --log ${TMP}/var/log/td-agent/td-agent.log --use-v1-config --daemon ${TMP}/var/run/td-agent/td-agent.pid
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub daemon
+}
+
+@test "start td-agent with custom configuration successfully (redhat)" {
+  rm -f "${TMP}/path/to/td-agent.pid"
+  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
+DAEMON_ARGS="--user nobody"
+PIDFILE="${TMP}/path/to/td-agent.pid"
+TD_AGENT_ARGS="/path/to/td-agent -vv --group nogroup --log /path/to/td-agent.log"
+EOS
+
+  stub daemon "echo; for arg; do echo \"  \$arg\"; done"
+
+  run_service start
+  assert_output <<EOS
+Starting td-agent: 
+  --pidfile=${TMP}/path/to/td-agent.pid
+  --user
+  nobody
+  ${TMP}/opt/td-agent/embedded/bin/ruby
+  /path/to/td-agent -vv --group nogroup --log /path/to/td-agent.log --daemon ${TMP}/path/to/td-agent.pid
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/td-agent" ]

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -24,7 +24,14 @@ Starting td-agent:
   --user
   td-agent
   ${TMP}/opt/td-agent/embedded/bin/ruby
-  ${TMP}/usr/sbin/td-agent --group td-agent --log ${TMP}/var/log/td-agent/td-agent.log --use-v1-config --daemon ${TMP}/var/run/td-agent/td-agent.pid
+  ${TMP}/usr/sbin/td-agent
+  --group
+  td-agent
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -52,7 +59,14 @@ Starting custom_name:
   --user
   td-agent
   ${TMP}/path/to/custom_process_bin
-  ${TMP}/usr/sbin/td-agent --group td-agent --log ${TMP}/var/log/td-agent/td-agent.log --use-v1-config --daemon ${TMP}/var/run/td-agent/custom_prog.pid
+  ${TMP}/usr/sbin/td-agent
+  --group
+  td-agent
+  --log
+  ${TMP}/var/log/td-agent/td-agent.log
+  --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/custom_prog.pid
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/custom_prog" ]
@@ -77,7 +91,14 @@ Starting td-agent:
   --user
   nobody
   ${TMP}/opt/td-agent/embedded/bin/ruby
-  /path/to/td-agent -vv --group nogroup --log /path/to/td-agent.log --daemon ${TMP}/path/to/td-agent.pid
+  /path/to/td-agent
+  -vv
+  --group
+  nogroup
+  --log
+  /path/to/td-agent.log
+  --daemon
+  ${TMP}/path/to/td-agent.pid
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/td-agent" ]

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -93,6 +93,28 @@ EOS
   unstub success
 }
 
+@test "stop td-agent by custom name successfully (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
+  touch "${TMP}/var/lock/subsys/custom_prog"
+  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
+prog="custom_prog"
+EOS
+
+  stub killproc "custom_prog : true"
+  stub success "true"
+
+  run_service stop
+  assert_output <<EOS
+Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Shutting down td-agent: 
+EOS
+  assert_success
+  [ ! -f "${TMP}/var/lock/subsys/custom_prog" ]
+
+  unstub killproc
+  unstub success
+}
+
 @test "failed to stop td-agent by name (redhat)" {
   rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   touch "${TMP}/var/lock/subsys/td-agent"

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -105,7 +105,7 @@ EOS
 
   run_service stop
   assert_output <<EOS
-Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
 Shutting down td-agent: 
 EOS
   assert_success

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -93,28 +93,6 @@ EOS
   unstub success
 }
 
-@test "stop td-agent by custom name successfully (redhat)" {
-  rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
-  touch "${TMP}/var/lock/subsys/custom_prog"
-  cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
-prog="custom_prog"
-EOS
-
-  stub killproc "custom_prog : true"
-  stub success "true"
-
-  run_service stop
-  assert_output <<EOS
-Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
-Shutting down td-agent: 
-EOS
-  assert_success
-  [ ! -f "${TMP}/var/lock/subsys/custom_prog" ]
-
-  unstub killproc
-  unstub success
-}
-
 @test "failed to stop td-agent by name (redhat)" {
   rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   touch "${TMP}/var/lock/subsys/td-agent"

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -105,7 +105,7 @@ EOS
 
   run_service stop
   assert_output <<EOS
-Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
+Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead.
 Shutting down td-agent: 
 EOS
   assert_success

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -1,8 +1,36 @@
 export TMP="${BATS_TEST_DIRNAME}/tmp"
 
+ORIG_PATH="${PATH}"
 PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 PATH="${TMP}/bin:${PATH}"
 export PATH
+
+# unset td-agent configuration variables
+unset DAEMON_ARGS
+unset NAME
+unset PIDFILE
+unset STOPTIMEOUT
+unset TD_AGENT_ARGS
+unset TD_AGENT_BIN_FILE
+unset TD_AGENT_DEFAULT
+unset TD_AGENT_GROUP
+unset TD_AGENT_HOME
+unset TD_AGENT_LOCK_FILE
+unset TD_AGENT_LOG_FILE
+unset TD_AGENT_NAME
+unset TD_AGENT_PID_FILE
+unset TD_AGENT_RUBY
+unset TD_AGENT_USER
+unset name
+unset process_bin
+unset prog
+
+render() {
+  # restore original PATH to run ruby within RVM on travis-ci.org
+  ( export PATH="${ORIG_PATH}"
+    "${BATS_TEST_DIRNAME}/render" "$@"
+  )
+}
 
 init_debian() {
   mkdir -p "${TMP}/bin"
@@ -10,7 +38,7 @@ init_debian() {
   mkdir -p "${TMP}/etc/default"
 
   mkdir -p "${TMP}/etc/init.d"
-  "${BATS_TEST_DIRNAME}/render" "${BATS_TEST_DIRNAME}/../templates/etc/init.d/deb/td-agent" > "${TMP}/etc/init.d/td-agent"
+  render "${BATS_TEST_DIRNAME}/../templates/etc/init.d/deb/td-agent" > "${TMP}/etc/init.d/td-agent"
   chmod +x "${TMP}/etc/init.d/td-agent"
 
   mkdir -p "${TMP}/lib/lsb"
@@ -55,7 +83,7 @@ init_redhat() {
   touch "${TMP}/etc/init.d/functions"
 
   mkdir -p "${TMP}/etc/init.d"
-  "${BATS_TEST_DIRNAME}/render" "${BATS_TEST_DIRNAME}/../templates/etc/init.d/rpm/td-agent" > "${TMP}/etc/init.d/td-agent"
+  render "${BATS_TEST_DIRNAME}/../templates/etc/init.d/rpm/td-agent" > "${TMP}/etc/init.d/td-agent"
   chmod +x "${TMP}/etc/init.d/td-agent"
 
   mkdir -p "${TMP}/etc/sysconfig"

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -176,6 +176,8 @@ assert_equal() {
   if [ "$1" != "$2" ]; then
     { echo "expected: $1"
       echo "actual:   $2"
+      echo "diff:"
+      diff -u <(echo "$1") <(echo "$2")
     } | flunk
   fi
 }

--- a/bats/usage_debian.bats
+++ b/bats/usage_debian.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_debian
+  stub_debian
+}
+
+teardown() {
+  unstub_debian
+  rm -fr "${TMP}"/*
+}
+
+@test "show td-agent usage on unknown action (debian)" {
+  run_service unknown
+  assert_output <<EOS
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|status|restart|force-reload|configtest}
+EOS
+  assert_failure
+}
+
+@test "show td-agent usage on missing action (debian)" {
+  run_service
+  assert_output <<EOS
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|status|restart|force-reload|configtest}
+EOS
+  assert_failure
+}

--- a/bats/usage_redhat.bats
+++ b/bats/usage_redhat.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  init_redhat
+  stub_redhat
+}
+
+teardown() {
+  unstub_redhat
+  rm -fr "${TMP}"/*
+}
+
+@test "show td-agent usage on unknown action (redhat)" {
+  run_service unknown
+  assert_output <<EOS
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|reload|restart|condrestart|status|configtest}
+EOS
+  assert_failure
+}
+
+@test "show td-agent usage on missing action (redhat)" {
+  run_service
+  assert_output <<EOS
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|reload|restart|condrestart|status|configtest}
+EOS
+  assert_failure
+}

--- a/config/software/td-agent-files.rb
+++ b/config/software/td-agent-files.rb
@@ -14,7 +14,6 @@ build do
     install_path = project.install_dir # for ERB
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
-    project_name_snake_upcase = project_name_snake.upcase
     gem_dir_version = "2.1.0"
 
     template = ->(*parts) { File.join('templates', *parts) }

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -12,9 +12,6 @@
 # Author: Kazuki Ohta <k@treasure-data.com>
 set -e
 
-# Introduce the short server's name here
-NAME=<%= Shellwords.shellescape(project_name) %>
-
 export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
 
 AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
@@ -22,6 +19,7 @@ AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
 AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "default", project_name)) %>
 AGENT_USER=<%= Shellwords.shellescape(project_name) %>
 AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
 AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
 AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
 AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
@@ -29,8 +27,14 @@ AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", pro
 # Read configuration variable file if it is present
 [ -r "${AGENT_DEFAULT}" ] && . "${AGENT_DEFAULT}"
 
+if [ -n "${NAME}" ]; then
+  # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
+  echo "Declaring \$NAME in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
+  AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
+fi
+
 DESC=<%= Shellwords.shellescape(project_name) %> # Introduce a short description here
-DAEMON="${AGENT_HOME}/embedded/bin/ruby" # Introduce the server's location here
+DAEMON="${AGENT_RUBY}" # Introduce the server's location here
 # Arguments to run the daemon with
 DAEMON_ARGS="${AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${AGENT_PID_FILE} --log ${AGENT_LOG_FILE} --use-v1-config"
 START_STOP_DAEMON_ARGS=""

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -12,7 +12,7 @@
 # Author: Kazuki Ohta <k@treasure-data.com>
 set -e
 
-export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
+export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map { |x| File.join(root_path, x)} + xs).uniq.join(":")) %>
 
 TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
 TD_AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -52,9 +52,7 @@ if [ -n "${AGENT_USER}" ]; then
     echo "$0: user for running <%= project_name %> doesn't exist: ${AGENT_USER}" >&2
     exit 1
   fi
-  if [ ! -d "$(dirname "${AGENT_PID_FILE}")" ]; then
-    mkdir -p "$(dirname "${AGENT_PID_FILE}")"
-  fi
+  mkdir -p "$(dirname "${AGENT_PID_FILE}")"
   chown -R "${AGENT_USER}" "$(dirname "${AGENT_PID_FILE}")"
   START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${AGENT_USER}"
 fi

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -78,7 +78,7 @@ do_start()
 {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
-  ulimit -n 65536
+  ulimit -n 65536 1>/dev/null 2>&1 || true
 
   # Return
   #   0 if daemon has been started

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -167,7 +167,7 @@ case "$1" in
   do_reload || RETVAL="$?"
   log_end_msg "$RETVAL"
   ;;
-"restart" | "force-reload" )
+"restart" )
   #
   # If the "reload" option is implemented then remove the
   # 'force-reload' alias

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -29,7 +29,7 @@ AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", pro
 
 if [ -n "${NAME}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Declaring \$NAME in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
+  echo "Warning: Declaring \$NAME in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
   AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
 fi
 

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -8,59 +8,64 @@
 # Short-Description: data collector for Treasure Data
 # Description:       Treasure Data Support <support@treasure-data.com>
 ### END INIT INFO
-
+<% require "shellwords" %>
 # Author: Kazuki Ohta <k@treasure-data.com>
 set -e
 
 # Introduce the short server's name here
-NAME=<%= project_name %>
+NAME=<%= Shellwords.shellescape(project_name) %>
+
+export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
+
+AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
+AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
+AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "default", project_name)) %>
+AGENT_USER=<%= Shellwords.shellescape(project_name) %>
+AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
+AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
+AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 
 # Read configuration variable file if it is present
-[ -r <%= File.join(root_path, "etc/default/$NAME") %> ] && . <%= File.join(root_path, "etc/default/$NAME") %>
+[ -r "${AGENT_DEFAULT}" ] && . "${AGENT_DEFAULT}"
 
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=<%= "/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":") %>
-USER=<%= project_name %>                   # Running user
-GROUP=<%= project_name %>                  # Running group
-DESC=<%= project_name %>                   # Introduce a short description here
-PIDFILE=<%= File.join(root_path, "var/run/$NAME/$NAME.pid") %>
-DAEMON=<%= File.join(root_path, install_path, "embedded/bin/ruby") %> # Introduce the server's location here
+DESC=<%= Shellwords.shellescape(project_name) %> # Introduce a short description here
+DAEMON="${AGENT_HOME}/embedded/bin/ruby" # Introduce the server's location here
 # Arguments to run the daemon with
-DAEMON_ARGS="<%= File.join(root_path, "usr/sbin", project_name) %> $DAEMON_ARGS --daemon $PIDFILE --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config"
-SCRIPTNAME=<%= File.join(root_path, "etc/init.d/$NAME") %>
+DAEMON_ARGS="${AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${AGENT_PID_FILE} --log ${AGENT_LOG_FILE} --use-v1-config"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
-[ -x $DAEMON ] || exit 0
+[ -x "$DAEMON" ] || exit 0
 
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
-. <%= File.join(root_path, "lib/lsb/init-functions") %>
+. <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %>
 
 # Check the user
-if [ -n "${USER}" ]; then
-  if ! getent passwd | grep -q "^${USER}:"; then
-    echo "$0: user for running <%= project_name %> doesn't exist: ${USER}" >&2
+if [ -n "${AGENT_USER}" ]; then
+  if ! getent passwd | grep -q "^${AGENT_USER}:"; then
+    echo "$0: user for running <%= project_name %> doesn't exist: ${AGENT_USER}" >&2
     exit 1
   fi
-  if [ ! -d $(dirname ${PIDFILE}) ]; then
-    mkdir -p $(dirname ${PIDFILE})
+  if [ ! -d "$(dirname "${AGENT_PID_FILE}")" ]; then
+    mkdir -p "$(dirname "${AGENT_PID_FILE}")"
   fi
-  chown -R ${USER} $(dirname ${PIDFILE})
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${USER}"
+  chown -R "${AGENT_USER}" "$(dirname "${AGENT_PID_FILE}")"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${AGENT_USER}"
 fi
-if [ -n "${GROUP}" ]; then
-  if ! getent group | grep -q "^${GROUP}:"; then
-    echo "$0: group for running <%= project_name %> doesn't exist: ${GROUP}" >&2
+if [ -n "${AGENT_GROUP}" ]; then
+  if ! getent group | grep -q "^${AGENT_GROUP}:"; then
+    echo "$0: group for running <%= project_name %> doesn't exist: ${AGENT_GROUP}" >&2
     exit 1
   fi
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${GROUP}"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${AGENT_GROUP}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # Use jemalloc to avoid memory fragmentation
-if [ -f "<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>" ]; then
-  export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
+if [ -f "${AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
+  export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 #
@@ -76,10 +81,10 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+  start-stop-daemon --start --quiet --pidfile "${AGENT_PID_FILE}" --exec "${DAEMON}" \
     ${START_STOP_DAEMON_ARGS} --test > /dev/null \
     || return 1
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+  start-stop-daemon --start --quiet --pidfile "${AGENT_PID_FILE}" --exec "${DAEMON}" \
     ${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
@@ -98,7 +103,7 @@ do_stop()
   #   2 if daemon could not be stopped
   #   other if a failure occurred
   local RETVAL=0
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name ruby || RETVAL="$?"
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "${AGENT_PID_FILE}" --name ruby || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Wait for children to finish too if this is a daemon that forks
   # and if the daemon is only ever run from this initscript.
@@ -106,10 +111,10 @@ do_stop()
   # that waits for the process to drop all resources that could be
   # needed by services started subsequently.  A last resort is to
   # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON || RETVAL="$?"
+  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "${DAEMON}" || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
-  rm -f $PIDFILE
+  rm -f "${AGENT_PID_FILE}"
   return "$RETVAL"
 }
 
@@ -122,17 +127,17 @@ do_reload() {
   # restarting (for example, when it is sent a SIGHUP),
   # then implement that here.
   #
-  start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name ruby
+  start-stop-daemon --stop --signal 1 --quiet --pidfile "${AGENT_PID_FILE}" --name ruby
 }
 
 do_configtest() {
-  eval "$DAEMON_ARGS --user ${USER} --group ${GROUP} --dry-run -q"
+  eval "$DAEMON_ARGS --user ${AGENT_USER} --group ${AGENT_GROUP} --dry-run -q"
 }
 
 RETVAL=0
 case "$1" in
 "start" )
-  log_daemon_msg "Starting $DESC " "$NAME"
+  log_daemon_msg "Starting $DESC " "${AGENT_NAME}"
   do_start || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -140,7 +145,7 @@ case "$1" in
   esac
   ;;
 "stop" )
-  log_daemon_msg "Stopping $DESC" "$NAME"
+  log_daemon_msg "Stopping $DESC" "${AGENT_NAME}"
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -148,14 +153,14 @@ case "$1" in
   esac
   ;;
 "status" )
-  status_of_proc "$DAEMON" "$NAME"
+  status_of_proc "${DAEMON}" "${AGENT_NAME}"
   ;;
 "reload" | "force-reload" )
   #
   # If do_reload() is not implemented then leave this commented out
   # and leave 'force-reload' as an alias for 'restart'.
   #
-  log_daemon_msg "Reloading $DESC" "$NAME"
+  log_daemon_msg "Reloading $DESC" "${AGENT_NAME}"
   do_configtest || log_end_msg 1
   do_reload || RETVAL="$?"
   log_end_msg "$RETVAL"
@@ -165,7 +170,7 @@ case "$1" in
   # If the "reload" option is implemented then remove the
   # 'force-reload' alias
   #
-  log_daemon_msg "Restarting $DESC" "$NAME"
+  log_daemon_msg "Restarting $DESC" "${AGENT_NAME}"
   do_configtest || log_end_msg 1
   do_stop || RETVAL="$?"
   case "$RETVAL" in
@@ -189,7 +194,7 @@ case "$1" in
   log_end_msg "$RETVAL"
   ;;
 * )
-  echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
+  echo "Usage: $0 {start|stop|status|restart|force-reload|configtest}" >&2
   exit 3
   ;;
 esac

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -39,28 +39,28 @@ START_STOP_DAEMON_ARGS=""
 
 # Check the user
 if [ -n "${USER}" ]; then
-	if ! getent passwd | grep -q "^${USER}:"; then
-		echo "$0: user for running <%= project_name %> doesn't exist: ${USER}" >&2
-		exit 1
-	fi
-	if [ ! -d $(dirname ${PIDFILE}) ]; then
-		mkdir -p $(dirname ${PIDFILE})
-	fi
-	chown -R ${USER} $(dirname ${PIDFILE})
-	START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${USER}"
+  if ! getent passwd | grep -q "^${USER}:"; then
+    echo "$0: user for running <%= project_name %> doesn't exist: ${USER}" >&2
+    exit 1
+  fi
+  if [ ! -d $(dirname ${PIDFILE}) ]; then
+    mkdir -p $(dirname ${PIDFILE})
+  fi
+  chown -R ${USER} $(dirname ${PIDFILE})
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${USER}"
 fi
 if [ -n "${GROUP}" ]; then
-	if ! getent group | grep -q "^${GROUP}:"; then
-		echo "$0: group for running <%= project_name %> doesn't exist: ${GROUP}" >&2
-		exit 1
-	fi
-	START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${GROUP}"
+  if ! getent group | grep -q "^${GROUP}:"; then
+    echo "$0: group for running <%= project_name %> doesn't exist: ${GROUP}" >&2
+    exit 1
+  fi
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${GROUP}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # Use jemalloc to avoid memory fragmentation
 if [ -f "<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>" ]; then
-	export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
+  export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
 fi
 
 #
@@ -68,23 +68,23 @@ fi
 #
 do_start()
 {
-	# Set Max number of file descriptors for the safety sake
-	# see http://docs.fluentd.org/en/articles/before-install
-	ulimit -n 65536
+  # Set Max number of file descriptors for the safety sake
+  # see http://docs.fluentd.org/en/articles/before-install
+  ulimit -n 65536
 
-	# Return
-	#   0 if daemon has been started
-	#   1 if daemon was already running
-	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
-	${START_STOP_DAEMON_ARGS} --test > /dev/null \
-		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
-	${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
-		|| return 2
-	# Add code here, if necessary, that waits for the process to be ready
-	# to handle requests from services started subsequently which depend
-	# on this one.  As a last resort, sleep for some time.
+  # Return
+  #   0 if daemon has been started
+  #   1 if daemon was already running
+  #   2 if daemon could not be started
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+    ${START_STOP_DAEMON_ARGS} --test > /dev/null \
+    || return 1
+  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+    ${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
+    || return 2
+  # Add code here, if necessary, that waits for the process to be ready
+  # to handle requests from services started subsequently which depend
+  # on this one.  As a last resort, sleep for some time.
 }
 
 #
@@ -92,106 +92,106 @@ do_start()
 #
 do_stop()
 {
-	# Return
-	#   0 if daemon has been stopped
-	#   1 if daemon was already stopped
-	#   2 if daemon could not be stopped
-	#   other if a failure occurred
-	local RETVAL=0
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name ruby || RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Wait for children to finish too if this is a daemon that forks
-	# and if the daemon is only ever run from this initscript.
-	# If the above conditions are not satisfied then add some other code
-	# that waits for the process to drop all resources that could be
-	# needed by services started subsequently.  A last resort is to
-	# sleep for some time.
-	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON || RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
-	return "$RETVAL"
+  # Return
+  #   0 if daemon has been stopped
+  #   1 if daemon was already stopped
+  #   2 if daemon could not be stopped
+  #   other if a failure occurred
+  local RETVAL=0
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name ruby || RETVAL="$?"
+  [ "$RETVAL" = 2 ] && return 2
+  # Wait for children to finish too if this is a daemon that forks
+  # and if the daemon is only ever run from this initscript.
+  # If the above conditions are not satisfied then add some other code
+  # that waits for the process to drop all resources that could be
+  # needed by services started subsequently.  A last resort is to
+  # sleep for some time.
+  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON || RETVAL="$?"
+  [ "$RETVAL" = 2 ] && return 2
+  # Many daemons don't delete their pidfiles when they exit.
+  rm -f $PIDFILE
+  return "$RETVAL"
 }
 
 #
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-	#
-	# If the daemon can reload its configuration without
-	# restarting (for example, when it is sent a SIGHUP),
-	# then implement that here.
-	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name ruby
+  #
+  # If the daemon can reload its configuration without
+  # restarting (for example, when it is sent a SIGHUP),
+  # then implement that here.
+  #
+  start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name ruby
 }
 
 do_configtest() {
-	eval "$DAEMON_ARGS --user ${USER} --group ${GROUP} --dry-run -q"
+  eval "$DAEMON_ARGS --user ${USER} --group ${GROUP} --dry-run -q"
 }
 
 RETVAL=0
 case "$1" in
-  start)
-    log_daemon_msg "Starting $DESC " "$NAME"
+"start" )
+  log_daemon_msg "Starting $DESC " "$NAME"
+  do_start || RETVAL="$?"
+  case "$RETVAL" in
+  0 | 1 ) log_end_msg 0 ;;
+      2 ) log_end_msg 1 ;;
+  esac
+  ;;
+"stop" )
+  log_daemon_msg "Stopping $DESC" "$NAME"
+  do_stop || RETVAL="$?"
+  case "$RETVAL" in
+  0 | 1 ) log_end_msg 0 ;;
+      2 ) log_end_msg 1 ;;
+  esac
+  ;;
+"status" )
+  status_of_proc "$DAEMON" "$NAME"
+  ;;
+"reload" | "force-reload" )
+  #
+  # If do_reload() is not implemented then leave this commented out
+  # and leave 'force-reload' as an alias for 'restart'.
+  #
+  log_daemon_msg "Reloading $DESC" "$NAME"
+  do_configtest || log_end_msg 1
+  do_reload || RETVAL="$?"
+  log_end_msg "$RETVAL"
+  ;;
+"restart" | "force-reload" )
+  #
+  # If the "reload" option is implemented then remove the
+  # 'force-reload' alias
+  #
+  log_daemon_msg "Restarting $DESC" "$NAME"
+  do_configtest || log_end_msg 1
+  do_stop || RETVAL="$?"
+  case "$RETVAL" in
+  0 | 1 )
+    RETVAL=0
     do_start || RETVAL="$?"
     case "$RETVAL" in
-		0|1) log_end_msg 0 ;;
-		2) log_end_msg 1 ;;
-	esac
+    0 ) log_end_msg 0 ;;
+    1 ) log_end_msg 1 ;; # Old process is still running
+    * ) log_end_msg 1 ;; # Failed to start
+    esac
+    ;;
+  * )
+    # Failed to stop
+    log_end_msg 1
+    ;;
+  esac
   ;;
-  stop)
-	log_daemon_msg "Stopping $DESC" "$NAME"
-	do_stop || RETVAL="$?"
-	case "$RETVAL" in
-		0|1) log_end_msg 0 ;;
-		2) log_end_msg 1 ;;
-	esac
-	;;
-  status)
-       status_of_proc "$DAEMON" "$NAME"
-       ;;
-  reload|force-reload)
-	#
-	# If do_reload() is not implemented then leave this commented out
-	# and leave 'force-reload' as an alias for 'restart'.
-	#
-	log_daemon_msg "Reloading $DESC" "$NAME"
-	do_configtest || log_end_msg 1
-	do_reload || RETVAL="$?"
-	log_end_msg "$RETVAL"
-	;;
-  restart|force-reload)
-	#
-	# If the "reload" option is implemented then remove the
-	# 'force-reload' alias
-	#
-	log_daemon_msg "Restarting $DESC" "$NAME"
-	do_configtest || log_end_msg 1
-	do_stop || RETVAL="$?"
-	case "$RETVAL" in
-	  0|1)
-		RETVAL=0
-		do_start || RETVAL="$?"
-		case "$RETVAL" in
-			0) log_end_msg 0 ;;
-			1) log_end_msg 1 ;; # Old process is still running
-			*) log_end_msg 1 ;; # Failed to start
-		esac
-		;;
-	  *)
-	  	# Failed to stop
-		log_end_msg 1
-		;;
-	esac
-	;;
-  configtest)
-	do_configtest || RETVAL="$?"
-		log_end_msg "$RETVAL"
-	;;
-  *)
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
-	exit 3
-	;;
+"configtest" )
+  do_configtest || RETVAL="$?"
+  log_end_msg "$RETVAL"
+  ;;
+* )
+  echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
+  exit 3
+  ;;
 esac
 
 :

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -25,7 +25,9 @@ TD_AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", 
 TD_AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 
 # Read configuration variable file if it is present
-[ -r "${TD_AGENT_DEFAULT}" ] && . "${TD_AGENT_DEFAULT}"
+if [ -f "${TD_AGENT_DEFAULT}" ]; then
+  . "${TD_AGENT_DEFAULT}"
+fi
 
 if [ -n "${NAME}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -14,29 +14,28 @@ set -e
 
 export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
 
-AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
-AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
-AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "default", project_name)) %>
-AGENT_USER=<%= Shellwords.shellescape(project_name) %>
-AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
-AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
-AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
-AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
-AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
+TD_AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "default", project_name)) %>
+TD_AGENT_USER=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
+TD_AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
+TD_AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
+TD_AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 
 # Read configuration variable file if it is present
-[ -r "${AGENT_DEFAULT}" ] && . "${AGENT_DEFAULT}"
+[ -r "${TD_AGENT_DEFAULT}" ] && . "${TD_AGENT_DEFAULT}"
 
 if [ -n "${NAME}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Warning: Declaring \$NAME in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
-  AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
+  echo "Warning: Declaring \$NAME in ${TD_AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead." 1>&2
+  TD_AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
 fi
 
-DESC=<%= Shellwords.shellescape(project_name) %> # Introduce a short description here
-DAEMON="${AGENT_RUBY}" # Introduce the server's location here
+DAEMON="${TD_AGENT_RUBY}" # Introduce the server's location here
 # Arguments to run the daemon with
-DAEMON_ARGS="${AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${AGENT_PID_FILE} --log ${AGENT_LOG_FILE} --use-v1-config"
+DAEMON_ARGS="${TD_AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${TD_AGENT_PID_FILE} --log ${TD_AGENT_LOG_FILE} --use-v1-config"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
@@ -47,27 +46,27 @@ START_STOP_DAEMON_ARGS=""
 . <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %>
 
 # Check the user
-if [ -n "${AGENT_USER}" ]; then
-  if ! getent passwd | grep -q "^${AGENT_USER}:"; then
-    echo "$0: user for running <%= project_name %> doesn't exist: ${AGENT_USER}" >&2
+if [ -n "${TD_AGENT_USER}" ]; then
+  if ! getent passwd | grep -q "^${TD_AGENT_USER}:"; then
+    echo "$0: user for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_USER}" >&2
     exit 1
   fi
-  mkdir -p "$(dirname "${AGENT_PID_FILE}")"
-  chown -R "${AGENT_USER}" "$(dirname "${AGENT_PID_FILE}")"
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${AGENT_USER}"
+  mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+  chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${TD_AGENT_USER}"
 fi
-if [ -n "${AGENT_GROUP}" ]; then
-  if ! getent group | grep -q "^${AGENT_GROUP}:"; then
-    echo "$0: group for running <%= project_name %> doesn't exist: ${AGENT_GROUP}" >&2
+if [ -n "${TD_AGENT_GROUP}" ]; then
+  if ! getent group | grep -q "^${TD_AGENT_GROUP}:"; then
+    echo "$0: group for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_GROUP}" >&2
     exit 1
   fi
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${AGENT_GROUP}"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${TD_AGENT_GROUP}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # Use jemalloc to avoid memory fragmentation
-if [ -f "${AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
-  export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
+if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
+  export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 #
@@ -83,10 +82,10 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile "${AGENT_PID_FILE}" --exec "${DAEMON}" \
+  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${DAEMON}" \
     ${START_STOP_DAEMON_ARGS} --test > /dev/null \
     || return 1
-  start-stop-daemon --start --quiet --pidfile "${AGENT_PID_FILE}" --exec "${DAEMON}" \
+  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${DAEMON}" \
     ${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
@@ -105,7 +104,7 @@ do_stop()
   #   2 if daemon could not be stopped
   #   other if a failure occurred
   local RETVAL=0
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "${AGENT_PID_FILE}" --name ruby || RETVAL="$?"
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "${TD_AGENT_PID_FILE}" --name ruby || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Wait for children to finish too if this is a daemon that forks
   # and if the daemon is only ever run from this initscript.
@@ -116,7 +115,7 @@ do_stop()
   start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "${DAEMON}" || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
-  rm -f "${AGENT_PID_FILE}"
+  rm -f "${TD_AGENT_PID_FILE}"
   return "$RETVAL"
 }
 
@@ -129,17 +128,17 @@ do_reload() {
   # restarting (for example, when it is sent a SIGHUP),
   # then implement that here.
   #
-  start-stop-daemon --stop --signal 1 --quiet --pidfile "${AGENT_PID_FILE}" --name ruby
+  start-stop-daemon --stop --signal 1 --quiet --pidfile "${TD_AGENT_PID_FILE}" --name ruby
 }
 
 do_configtest() {
-  eval "$DAEMON_ARGS --user ${AGENT_USER} --group ${AGENT_GROUP} --dry-run -q"
+  eval "$DAEMON_ARGS --user ${TD_AGENT_USER} --group ${TD_AGENT_GROUP} --dry-run -q"
 }
 
 RETVAL=0
 case "$1" in
 "start" )
-  log_daemon_msg "Starting $DESC " "${AGENT_NAME}"
+  log_daemon_msg "Starting ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
   do_start || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -147,7 +146,7 @@ case "$1" in
   esac
   ;;
 "stop" )
-  log_daemon_msg "Stopping $DESC" "${AGENT_NAME}"
+  log_daemon_msg "Stopping ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -155,14 +154,14 @@ case "$1" in
   esac
   ;;
 "status" )
-  status_of_proc "${DAEMON}" "${AGENT_NAME}"
+  status_of_proc "${DAEMON}" "${TD_AGENT_NAME}"
   ;;
 "reload" | "force-reload" )
   #
   # If do_reload() is not implemented then leave this commented out
   # and leave 'force-reload' as an alias for 'restart'.
   #
-  log_daemon_msg "Reloading $DESC" "${AGENT_NAME}"
+  log_daemon_msg "Reloading ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
   do_configtest || log_end_msg 1
   do_reload || RETVAL="$?"
   log_end_msg "$RETVAL"
@@ -172,7 +171,7 @@ case "$1" in
   # If the "reload" option is implemented then remove the
   # 'force-reload' alias
   #
-  log_daemon_msg "Restarting $DESC" "${AGENT_NAME}"
+  log_daemon_msg "Restarting ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
   do_configtest || log_end_msg 1
   do_stop || RETVAL="$?"
   case "$RETVAL" in

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -33,10 +33,6 @@ START_STOP_DAEMON_ARGS=""
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
 
-# Load the VERBOSE setting and other rcS variables
-# . <%= File.join(root_path, "lib/init/vars.sh") %>
-VERBOSE="yes"
-
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . <%= File.join(root_path, "lib/lsb/init-functions") %>
@@ -136,19 +132,19 @@ do_configtest() {
 RETVAL=0
 case "$1" in
   start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC " "$NAME"
+    log_daemon_msg "Starting $DESC " "$NAME"
     do_start || RETVAL="$?"
     case "$RETVAL" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		0|1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
 	esac
   ;;
   stop)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	log_daemon_msg "Stopping $DESC" "$NAME"
 	do_stop || RETVAL="$?"
 	case "$RETVAL" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		0|1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
 	esac
 	;;
   status)

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -23,60 +23,60 @@ set -e
 
 export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
 
-AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
-AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
-AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "sysconfig", project_name)) %>
-AGENT_USER=<%= Shellwords.shellescape(project_name) %>
-AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
-AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
-AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
-AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
-AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
-AGENT_LOCK_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "lock", "subsys", project_name)) %>
+TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
+TD_AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "sysconfig", project_name)) %>
+TD_AGENT_USER=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+TD_AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
+TD_AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
+TD_AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
+TD_AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+TD_AGENT_LOCK_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "lock", "subsys", project_name)) %>
 
 # timeout can be overridden from <%= File.join(root_path, "etc/sysconfig", project_name) %>
 STOPTIMEOUT=120
 
-if [ -f "${AGENT_DEFAULT}" ]; then
-  . "${AGENT_DEFAULT}"
+if [ -f "${TD_AGENT_DEFAULT}" ]; then
+  . "${TD_AGENT_DEFAULT}"
 fi
 
 if [ -n "${name}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Warning: Declaring \$name in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_NAME instead." 1>&2
-  AGENT_NAME="${name}"
+  echo "Warning: Declaring \$name in ${TD_AGENT_DEFAULT} has been deprecated. Use \$TD_AGENT_NAME instead." 1>&2
+  TD_AGENT_NAME="${name}"
 fi
 
 if [ -n "${prog}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Warning: Declaring \$prog in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
+  echo "Warning: Declaring \$prog in ${TD_AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead." 1>&2
   [ -n "${PIDFILE}" ] || PIDFILE="<%= root_path %>/var/run/<%= project_name %>/${prog}.pid"
-  AGENT_LOCK_FILE="<%= root_path %>/var/lock/subsys/${prog}"
-  AGENT_PROG_NAME="${prog}"
+  TD_AGENT_LOCK_FILE="<%= root_path %>/var/lock/subsys/${prog}"
+  TD_AGENT_PROG_NAME="${prog}"
 else
-  unset AGENT_PROG_NAME
+  unset TD_AGENT_PROG_NAME
 fi
 
 if [ -n "${process_bin}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Warning: Declaring \$process_bin in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_RUBY instead." 1>&2
-  AGENT_RUBY="${process_bin}"
+  echo "Warning: Declaring \$process_bin in ${TD_AGENT_DEFAULT} has been deprecated. Use \$TD_AGENT_RUBY instead." 1>&2
+  TD_AGENT_RUBY="${process_bin}"
 fi
 
-PIDFILE="${PIDFILE-${AGENT_PID_FILE}}"
-DAEMON_ARGS="${DAEMON_ARGS---user ${AGENT_USER}}"
-TD_AGENT_ARGS="${TD_AGENT_ARGS-${AGENT_BIN_FILE} --group ${AGENT_GROUP} --log ${AGENT_LOG_FILE} --use-v1-config}"
+PIDFILE="${PIDFILE-${TD_AGENT_PID_FILE}}"
+DAEMON_ARGS="${DAEMON_ARGS---user ${TD_AGENT_USER}}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS-${TD_AGENT_BIN_FILE} --group ${TD_AGENT_GROUP} --log ${TD_AGENT_LOG_FILE} --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
   mkdir -p "$(dirname "${PIDFILE}")"
-  chown -R "${AGENT_USER}:${AGENT_GROUP}" "$(dirname "${PIDFILE}")"
+  chown -R "${TD_AGENT_USER}:${TD_AGENT_GROUP}" "$(dirname "${PIDFILE}")"
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # use jemalloc to avoid fragmentation
-if [ -f "${AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
-  export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
+if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
+  export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 RETVAL=0
@@ -85,16 +85,16 @@ do_start() {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
   ulimit -n 65536
-  echo -n "Starting ${AGENT_NAME}: "
+  echo -n "Starting ${TD_AGENT_NAME}: "
   local RETVAL=0
-  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
+  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${TD_AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
   echo
-  [ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
+  [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
 
 do_stop() {
-  echo -n "Shutting down ${AGENT_NAME}: "
+  echo -n "Shutting down ${TD_AGENT_NAME}: "
   local RETVAL=0
   if [ -e "${PIDFILE}" ]; then
     # Use own process termination instead of killproc because killproc can't wait SIGTERM
@@ -109,7 +109,7 @@ do_stop() {
           let TIMEOUT="${TIMEOUT}-1" || true
         done
         if [ "$TIMEOUT" -eq 0 ]; then
-          echo -n "Timeout error occurred trying to stop ${AGENT_NAME}..."
+          echo -n "Timeout error occurred trying to stop ${TD_AGENT_NAME}..."
           RETVAL=1
           failure || true
         else
@@ -124,7 +124,7 @@ do_stop() {
       RETVAL=4
     fi
   else
-    killproc "${AGENT_PROG_NAME:-${AGENT_NAME}}" || RETVAL="$?"
+    killproc "${TD_AGENT_PROG_NAME:-${TD_AGENT_NAME}}" || RETVAL="$?"
     if [ $RETVAL -eq 0 ]; then
       success
     else
@@ -132,7 +132,7 @@ do_stop() {
     fi
   fi
   echo
-  [ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${AGENT_LOCK_FILE}"
+  [ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
 
@@ -144,9 +144,9 @@ do_restart() {
 
 do_reload() {
   do_configtest || return $?
-  echo -n "Reloading ${AGENT_NAME}: "
+  echo -n "Reloading ${TD_AGENT_NAME}: "
   local RETVAL=0
-  killproc "${AGENT_RUBY}" -HUP || RETVAL="$?"
+  killproc "${TD_AGENT_RUBY}" -HUP || RETVAL="$?"
   echo
   return "$RETVAL"
 }
@@ -169,7 +169,7 @@ case "$1" in
   do_reload
   ;;
 "condrestart" )
-  [ -f "${AGENT_LOCK_FILE}" ] && do_restart || :
+  [ -f "${TD_AGENT_LOCK_FILE}" ] && do_restart || :
   ;;
 "configtest" )
   do_configtest
@@ -177,7 +177,7 @@ case "$1" in
 "status" )
   # `status` is a function defined in RedHat's `/etc/init.d/functions` and it doesn't work well with `set -e`
   set +e
-  status -p "$PIDFILE" "${AGENT_NAME}"
+  status -p "$PIDFILE" "${TD_AGENT_NAME}"
   ;;
 * )
   echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}"

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -90,7 +90,7 @@ do_start() {
   ulimit -n 65536
   echo -n "Starting ${AGENT_NAME}: "
   local RETVAL=0
-  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_RUBY}" "$TD_AGENT_ARGS" || RETVAL="$?"
+  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
   echo
   [ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
   return $RETVAL

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -15,39 +15,47 @@
 # Short-Description: <%= project_name %>'s init script
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO
-
+<% require "shellwords" %>
 # Source function library.
 . <%= File.join(root_path, "etc/init.d/functions") %>
 
 set -e
 
-name="<%= project_name %>"
-prog="<%= project_name %>"
-process_bin=<%= File.join(root_path, install_path, "embedded/bin/ruby") %>
+export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
+
+AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
+AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
+AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "sysconfig", project_name)) %>
+AGENT_USER=<%= Shellwords.shellescape(project_name) %>
+AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
+AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
+AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+AGENT_LOCK_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "lock", "subsys", project_name)) %>
 
 # timeout can be overridden from <%= File.join(root_path, "etc/sysconfig", project_name) %>
 STOPTIMEOUT=120
 
-if [ -f <%= File.join(root_path, "etc/sysconfig/$prog") %> ]; then
-	. <%= File.join(root_path, "etc/sysconfig/$prog") %>
+if [ -f "${AGENT_DEFAULT}" ]; then
+	. "${AGENT_DEFAULT}"
 fi
-PIDFILE=${PIDFILE-<%= File.join(root_path, "var/run", project_name, "$prog.pid") %>}
-DAEMON_ARGS=${DAEMON_ARGS---user <%= project_name %>}
-TD_AGENT_ARGS="${TD_AGENT_ARGS-<%= File.join(root_path, "usr/sbin", project_name) %> --group <%= project_name %> --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config}"
+PIDFILE="${PIDFILE-${AGENT_PID_FILE}}"
+DAEMON_ARGS="${DAEMON_ARGS---user ${AGENT_USER}}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS-${AGENT_BIN_FILE} --group ${AGENT_GROUP} --log ${AGENT_LOG_FILE} --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
-	PIDFILE_DIR=$(dirname ${PIDFILE})
-	if [ ! -e $PIDFILE_DIR ]; then
-		mkdir -p $PIDFILE_DIR
+	PIDFILE_DIR="$(dirname "${PIDFILE}")"
+	if [ ! -e "$PIDFILE_DIR" ]; then
+		mkdir -p "$PIDFILE_DIR"
 	fi
-	chown -R <%= project_name %>:<%= project_name %> $PIDFILE_DIR
+	chown -R "${AGENT_USER}:${AGENT_GROUP}" "$PIDFILE_DIR"
 	TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # use jemalloc to avoid fragmentation
-if [ -f "<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>" ]; then
-        export LD_PRELOAD=<%= File.join(root_path, install_path, "embedded/lib/libjemalloc.so") %>
+if [ -f "${AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
+        export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 RETVAL=0
@@ -56,16 +64,16 @@ do_start() {
 	# Set Max number of file descriptors for the safety sake
 	# see http://docs.fluentd.org/en/articles/before-install
 	ulimit -n 65536
-	echo -n "Starting $name: "
+	echo -n "Starting ${AGENT_NAME}: "
 	local RETVAL=0
-	daemon --pidfile=$PIDFILE $DAEMON_ARGS $process_bin "$TD_AGENT_ARGS" || RETVAL="$?"
+	daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_HOME}/embedded/bin/ruby" "$TD_AGENT_ARGS" || RETVAL="$?"
 	echo
-	[ $RETVAL -eq 0 ] && touch <%= File.join(root_path, "var/lock/subsys/$prog") %>
+	[ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
 	return $RETVAL
 }
 
 do_stop() {
-	echo -n "Shutting down $name: "
+	echo -n "Shutting down ${AGENT_NAME}: "
 	local RETVAL=0
 	if [ -e "${PIDFILE}" ]; then
 	    # Use own process termination instead of killproc because killproc can't wait SIGTERM
@@ -77,10 +85,10 @@ do_stop() {
 		    while [ $TIMEOUT -gt 0 ]; do
 			<%= File.join(root_path, "bin/kill") %> -0 "$TD_AGENT_PID" >/dev/null 2>&1 || break
 			sleep 1
-			let TIMEOUT=${TIMEOUT}-1 || true
+			let TIMEOUT="${TIMEOUT}-1" || true
 		    done
-		    if [ $TIMEOUT -eq 0 ]; then
-			echo -n "Timeout error occurred trying to stop <%= project_name %>..."
+		    if [ "$TIMEOUT" -eq 0 ]; then
+			echo -n "Timeout error occurred trying to stop ${AGENT_NAME}..."
 			RETVAL=1
 			failure || true
 		    else
@@ -95,7 +103,7 @@ do_stop() {
 		RETVAL=4
 	    fi
 	else
-	    killproc $prog || RETVAL="$?"
+	    killproc "${AGENT_NAME}" || RETVAL="$?"
 	    if [ $RETVAL -eq 0 ]; then
 		success
 	    else
@@ -103,7 +111,7 @@ do_stop() {
 	    fi
 	fi
 	echo
-	[ $RETVAL -eq 0 ] && rm -f $PIDFILE && rm -f <%= File.join(root_path, "var/lock/subsys/$prog") %>
+	[ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${AGENT_LOCK_FILE}"
 	return $RETVAL
 }
 
@@ -115,9 +123,9 @@ do_restart() {
 
 do_reload() {
 	do_configtest || return $?
-	echo -n "Reloading $name: "
+	echo -n "Reloading ${AGENT_NAME}: "
 	local RETVAL=0
-	killproc $process_bin -HUP || RETVAL="$?"
+	killproc "${AGENT_HOME}/embedded/bin/ruby" -HUP || RETVAL="$?"
 	echo
 	return "$RETVAL"
 }
@@ -140,7 +148,7 @@ case "$1" in
 	do_reload
 	;;
     condrestart)
-	[ -f <%= File.join(root_path, "var/lock/subsys/$prog") %> ] && do_restart || :
+	[ -f "${AGENT_LOCK_FILE}" ] && do_restart || :
 	;;
     configtest)
         do_configtest
@@ -148,10 +156,10 @@ case "$1" in
     status)
 	# `status` is a function defined in RedHat's `/etc/init.d/functions` and it doesn't work well with `set -e`
 	set +e
-	status -p $PIDFILE '<%= project_name %>'
+	status -p "$PIDFILE" "${AGENT_NAME}"
 	;;
     *)
-	echo "Usage: $prog {start|stop|reload|restart|condrestart|status|configtest}"
+	echo "Usage: ${AGENT_NAME} {start|stop|reload|restart|condrestart|status|configtest}"
 	exit 1
 	;;
 esac

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -82,7 +82,7 @@ RETVAL=0
 do_start() {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
-  ulimit -n 65536
+  ulimit -n 65536 1>/dev/null 2>&1 || true
   echo -n "Starting ${TD_AGENT_NAME}: "
   local RETVAL=0
   daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${TD_AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -19,8 +19,6 @@
 # Source function library.
 . <%= File.join(root_path, "etc/init.d/functions") %>
 
-set -e
-
 export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
 
 TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -173,8 +173,6 @@ case "$1" in
   do_configtest
   ;;
 "status" )
-  # `status` is a function defined in RedHat's `/etc/init.d/functions` and it doesn't work well with `set -e`
-  set +e
   status -p "$PIDFILE" "${TD_AGENT_NAME}"
   ;;
 * )

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -28,6 +28,7 @@ AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
 AGENT_DEFAULT=<%= Shellwords.shellescape(File.join(root_path, "etc", "sysconfig", project_name)) %>
 AGENT_USER=<%= Shellwords.shellescape(project_name) %>
 AGENT_GROUP=<%= Shellwords.shellescape(project_name) %>
+AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "embedded", "bin", "ruby")) %>
 AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
 AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
 AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
@@ -39,6 +40,29 @@ STOPTIMEOUT=120
 if [ -f "${AGENT_DEFAULT}" ]; then
   . "${AGENT_DEFAULT}"
 fi
+
+if [ -n "${name}" ]; then
+  # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
+  echo "Declaring \$name in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_NAME instead." 1>&2
+  AGENT_NAME="${name}"
+fi
+
+if [ -n "${prog}" ]; then
+  # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
+  echo "Declaring \$prog in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
+  [ -n "${PIDFILE}" ] || PIDFILE="<%= root_path %>/var/run/<%= project_name %>/${prog}.pid"
+  AGENT_LOCK_FILE="<%= root_path %>/var/lock/subsys/${prog}"
+  AGENT_PROG_NAME="${prog}"
+else
+  unset AGENT_PROG_NAME
+fi
+
+if [ -n "${process_bin}" ]; then
+  # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
+  echo "Declaring \$process_bin in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_RUBY instead." 1>&2
+  AGENT_RUBY="${process_bin}"
+fi
+
 PIDFILE="${PIDFILE-${AGENT_PID_FILE}}"
 DAEMON_ARGS="${DAEMON_ARGS---user ${AGENT_USER}}"
 TD_AGENT_ARGS="${TD_AGENT_ARGS-${AGENT_BIN_FILE} --group ${AGENT_GROUP} --log ${AGENT_LOG_FILE} --use-v1-config}"
@@ -66,7 +90,7 @@ do_start() {
   ulimit -n 65536
   echo -n "Starting ${AGENT_NAME}: "
   local RETVAL=0
-  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_HOME}/embedded/bin/ruby" "$TD_AGENT_ARGS" || RETVAL="$?"
+  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_RUBY}" "$TD_AGENT_ARGS" || RETVAL="$?"
   echo
   [ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
   return $RETVAL
@@ -103,7 +127,7 @@ do_stop() {
       RETVAL=4
     fi
   else
-    killproc "${AGENT_NAME}" || RETVAL="$?"
+    killproc "${AGENT_PROG_NAME:-${AGENT_NAME}}" || RETVAL="$?"
     if [ $RETVAL -eq 0 ]; then
       success
     else
@@ -125,7 +149,7 @@ do_reload() {
   do_configtest || return $?
   echo -n "Reloading ${AGENT_NAME}: "
   local RETVAL=0
-  killproc "${AGENT_HOME}/embedded/bin/ruby" -HUP || RETVAL="$?"
+  killproc "${AGENT_RUBY}" -HUP || RETVAL="$?"
   echo
   return "$RETVAL"
 }

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -43,13 +43,13 @@ fi
 
 if [ -n "${name}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Declaring \$name in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_NAME instead." 1>&2
+  echo "Warning: Declaring \$name in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_NAME instead." 1>&2
   AGENT_NAME="${name}"
 fi
 
 if [ -n "${prog}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Declaring \$prog in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
+  echo "Warning: Declaring \$prog in ${AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$AGENT_PID_FILE instead." 1>&2
   [ -n "${PIDFILE}" ] || PIDFILE="<%= root_path %>/var/run/<%= project_name %>/${prog}.pid"
   AGENT_LOCK_FILE="<%= root_path %>/var/lock/subsys/${prog}"
   AGENT_PROG_NAME="${prog}"
@@ -59,7 +59,7 @@ fi
 
 if [ -n "${process_bin}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
-  echo "Declaring \$process_bin in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_RUBY instead." 1>&2
+  echo "Warning: Declaring \$process_bin in ${AGENT_DEFAULT} has been deprecated. Use \$AGENT_RUBY instead." 1>&2
   AGENT_RUBY="${process_bin}"
 fi
 

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -37,129 +37,129 @@ AGENT_LOCK_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "lock", "
 STOPTIMEOUT=120
 
 if [ -f "${AGENT_DEFAULT}" ]; then
-	. "${AGENT_DEFAULT}"
+  . "${AGENT_DEFAULT}"
 fi
 PIDFILE="${PIDFILE-${AGENT_PID_FILE}}"
 DAEMON_ARGS="${DAEMON_ARGS---user ${AGENT_USER}}"
 TD_AGENT_ARGS="${TD_AGENT_ARGS-${AGENT_BIN_FILE} --group ${AGENT_GROUP} --log ${AGENT_LOG_FILE} --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
-	PIDFILE_DIR="$(dirname "${PIDFILE}")"
-	if [ ! -e "$PIDFILE_DIR" ]; then
-		mkdir -p "$PIDFILE_DIR"
-	fi
-	chown -R "${AGENT_USER}:${AGENT_GROUP}" "$PIDFILE_DIR"
-	TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
+  PIDFILE_DIR="$(dirname "${PIDFILE}")"
+  if [ ! -e "$PIDFILE_DIR" ]; then
+    mkdir -p "$PIDFILE_DIR"
+  fi
+  chown -R "${AGENT_USER}:${AGENT_GROUP}" "$PIDFILE_DIR"
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
 # use jemalloc to avoid fragmentation
 if [ -f "${AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
-        export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
+  export LD_PRELOAD="${AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 RETVAL=0
 
 do_start() {
-	# Set Max number of file descriptors for the safety sake
-	# see http://docs.fluentd.org/en/articles/before-install
-	ulimit -n 65536
-	echo -n "Starting ${AGENT_NAME}: "
-	local RETVAL=0
-	daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_HOME}/embedded/bin/ruby" "$TD_AGENT_ARGS" || RETVAL="$?"
-	echo
-	[ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
-	return $RETVAL
+  # Set Max number of file descriptors for the safety sake
+  # see http://docs.fluentd.org/en/articles/before-install
+  ulimit -n 65536
+  echo -n "Starting ${AGENT_NAME}: "
+  local RETVAL=0
+  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${AGENT_HOME}/embedded/bin/ruby" "$TD_AGENT_ARGS" || RETVAL="$?"
+  echo
+  [ $RETVAL -eq 0 ] && touch "${AGENT_LOCK_FILE}"
+  return $RETVAL
 }
 
 do_stop() {
-	echo -n "Shutting down ${AGENT_NAME}: "
-	local RETVAL=0
-	if [ -e "${PIDFILE}" ]; then
-	    # Use own process termination instead of killproc because killproc can't wait SIGTERM
-	    TD_AGENT_PID=`cat "$PIDFILE" 2>/dev/null`
-	    if [ -n "$TD_AGENT_PID" ]; then
-		<%= File.join(root_path, "bin/kill") %> "$TD_AGENT_PID" >/dev/null 2>&1 || RETVAL="$?"
-		if [ $RETVAL -eq 0 ]; then
-		    TIMEOUT="$STOPTIMEOUT"
-		    while [ $TIMEOUT -gt 0 ]; do
-			<%= File.join(root_path, "bin/kill") %> -0 "$TD_AGENT_PID" >/dev/null 2>&1 || break
-			sleep 1
-			let TIMEOUT="${TIMEOUT}-1" || true
-		    done
-		    if [ "$TIMEOUT" -eq 0 ]; then
-			echo -n "Timeout error occurred trying to stop ${AGENT_NAME}..."
-			RETVAL=1
-			failure || true
-		    else
-			RETVAL=0
-			success
-		    fi
-		else
-		    failure || true
-		fi
-	    else
-		failure || true
-		RETVAL=4
-	    fi
-	else
-	    killproc "${AGENT_NAME}" || RETVAL="$?"
-	    if [ $RETVAL -eq 0 ]; then
-		success
-	    else
-		failure || true
-	    fi
-	fi
-	echo
-	[ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${AGENT_LOCK_FILE}"
-	return $RETVAL
+  echo -n "Shutting down ${AGENT_NAME}: "
+  local RETVAL=0
+  if [ -e "${PIDFILE}" ]; then
+    # Use own process termination instead of killproc because killproc can't wait SIGTERM
+    TD_AGENT_PID=`cat "$PIDFILE" 2>/dev/null`
+    if [ -n "$TD_AGENT_PID" ]; then
+      <%= File.join(root_path, "bin/kill") %> "$TD_AGENT_PID" >/dev/null 2>&1 || RETVAL="$?"
+      if [ $RETVAL -eq 0 ]; then
+        TIMEOUT="$STOPTIMEOUT"
+        while [ $TIMEOUT -gt 0 ]; do
+          <%= File.join(root_path, "bin/kill") %> -0 "$TD_AGENT_PID" >/dev/null 2>&1 || break
+          sleep 1
+          let TIMEOUT="${TIMEOUT}-1" || true
+        done
+        if [ "$TIMEOUT" -eq 0 ]; then
+          echo -n "Timeout error occurred trying to stop ${AGENT_NAME}..."
+          RETVAL=1
+          failure || true
+        else
+          RETVAL=0
+          success
+        fi
+      else
+        failure || true
+      fi
+    else
+      failure || true
+      RETVAL=4
+    fi
+  else
+    killproc "${AGENT_NAME}" || RETVAL="$?"
+    if [ $RETVAL -eq 0 ]; then
+      success
+    else
+      failure || true
+    fi
+  fi
+  echo
+  [ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${AGENT_LOCK_FILE}"
+  return $RETVAL
 }
 
 do_restart() {
-	do_configtest || return $?
-	do_stop || true
-	do_start
+  do_configtest || return $?
+  do_stop || true
+  do_start
 }
 
 do_reload() {
-	do_configtest || return $?
-	echo -n "Reloading ${AGENT_NAME}: "
-	local RETVAL=0
-	killproc "${AGENT_HOME}/embedded/bin/ruby" -HUP || RETVAL="$?"
-	echo
-	return "$RETVAL"
+  do_configtest || return $?
+  echo -n "Reloading ${AGENT_NAME}: "
+  local RETVAL=0
+  killproc "${AGENT_HOME}/embedded/bin/ruby" -HUP || RETVAL="$?"
+  echo
+  return "$RETVAL"
 }
 
 do_configtest() {
-	eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
+  eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
 }
 
 case "$1" in
-    start)
-	do_start
-	;;
-    stop)
-	do_stop
-	;;
-    restart)
-	do_restart
-	;;
-    reload)
-	do_reload
-	;;
-    condrestart)
-	[ -f "${AGENT_LOCK_FILE}" ] && do_restart || :
-	;;
-    configtest)
-        do_configtest
-        ;;
-    status)
-	# `status` is a function defined in RedHat's `/etc/init.d/functions` and it doesn't work well with `set -e`
-	set +e
-	status -p "$PIDFILE" "${AGENT_NAME}"
-	;;
-    *)
-	echo "Usage: ${AGENT_NAME} {start|stop|reload|restart|condrestart|status|configtest}"
-	exit 1
-	;;
+"start" )
+  do_start
+  ;;
+"stop" )
+  do_stop
+  ;;
+"restart" )
+  do_restart
+  ;;
+"reload" )
+  do_reload
+  ;;
+"condrestart" )
+  [ -f "${AGENT_LOCK_FILE}" ] && do_restart || :
+  ;;
+"configtest" )
+  do_configtest
+  ;;
+"status" )
+  # `status` is a function defined in RedHat's `/etc/init.d/functions` and it doesn't work well with `set -e`
+  set +e
+  status -p "$PIDFILE" "${AGENT_NAME}"
+  ;;
+* )
+  echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}"
+  exit 1
+  ;;
 esac

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -68,11 +68,8 @@ DAEMON_ARGS="${DAEMON_ARGS---user ${AGENT_USER}}"
 TD_AGENT_ARGS="${TD_AGENT_ARGS-${AGENT_BIN_FILE} --group ${AGENT_GROUP} --log ${AGENT_LOG_FILE} --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
-  PIDFILE_DIR="$(dirname "${PIDFILE}")"
-  if [ ! -e "$PIDFILE_DIR" ]; then
-    mkdir -p "$PIDFILE_DIR"
-  fi
-  chown -R "${AGENT_USER}:${AGENT_GROUP}" "$PIDFILE_DIR"
+  mkdir -p "$(dirname "${PIDFILE}")"
+  chown -R "${AGENT_USER}:${AGENT_GROUP}" "$(dirname "${PIDFILE}")"
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
 fi
 

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -33,7 +33,7 @@ if [ -f <%= File.join(root_path, "etc/sysconfig/$prog") %> ]; then
 fi
 PIDFILE=${PIDFILE-<%= File.join(root_path, "var/run", project_name, "$prog.pid") %>}
 DAEMON_ARGS=${DAEMON_ARGS---user <%= project_name %>}
-<%= project_name_snake_upcase %>_ARGS="${<%= project_name_snake_upcase %>_ARGS-<%= File.join(root_path, "usr/sbin", project_name) %> --group <%= project_name %> --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS-<%= File.join(root_path, "usr/sbin", project_name) %> --group <%= project_name %> --log <%= File.join(root_path, "var/log", project_name, "#{project_name}.log") %> --use-v1-config}"
 
 if [ -n "${PIDFILE}" ]; then
 	PIDFILE_DIR=$(dirname ${PIDFILE})
@@ -41,7 +41,7 @@ if [ -n "${PIDFILE}" ]; then
 		mkdir -p $PIDFILE_DIR
 	fi
 	chown -R <%= project_name %>:<%= project_name %> $PIDFILE_DIR
-	<%= project_name_snake_upcase %>_ARGS="${<%= project_name_snake_upcase %>_ARGS} --daemon ${PIDFILE}"
+	TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
@@ -58,7 +58,7 @@ do_start() {
 	ulimit -n 65536
 	echo -n "Starting $name: "
 	local RETVAL=0
-	daemon --pidfile=$PIDFILE $DAEMON_ARGS $process_bin "$<%= project_name_snake_upcase %>_ARGS" || RETVAL="$?"
+	daemon --pidfile=$PIDFILE $DAEMON_ARGS $process_bin "$TD_AGENT_ARGS" || RETVAL="$?"
 	echo
 	[ $RETVAL -eq 0 ] && touch <%= File.join(root_path, "var/lock/subsys/$prog") %>
 	return $RETVAL
@@ -69,13 +69,13 @@ do_stop() {
 	local RETVAL=0
 	if [ -e "${PIDFILE}" ]; then
 	    # Use own process termination instead of killproc because killproc can't wait SIGTERM
-	    <%= project_name_snake_upcase %>_PID=`cat "$PIDFILE" 2>/dev/null`
-	    if [ -n "$<%= project_name_snake_upcase %>_PID" ]; then
-		<%= File.join(root_path, "bin/kill") %> "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || RETVAL="$?"
+	    TD_AGENT_PID=`cat "$PIDFILE" 2>/dev/null`
+	    if [ -n "$TD_AGENT_PID" ]; then
+		<%= File.join(root_path, "bin/kill") %> "$TD_AGENT_PID" >/dev/null 2>&1 || RETVAL="$?"
 		if [ $RETVAL -eq 0 ]; then
 		    TIMEOUT="$STOPTIMEOUT"
 		    while [ $TIMEOUT -gt 0 ]; do
-			<%= File.join(root_path, "bin/kill") %> -0 "$<%= project_name_snake_upcase %>_PID" >/dev/null 2>&1 || break
+			<%= File.join(root_path, "bin/kill") %> -0 "$TD_AGENT_PID" >/dev/null 2>&1 || break
 			sleep 1
 			let TIMEOUT=${TIMEOUT}-1 || true
 		    done
@@ -123,7 +123,7 @@ do_reload() {
 }
 
 do_configtest() {
-	eval "$<%= project_name_snake_upcase %>_ARGS $DAEMON_ARGS --dry-run -q"
+	eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
 }
 
 case "$1" in

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -19,7 +19,7 @@
 # Source function library.
 . <%= File.join(root_path, "etc/init.d/functions") %>
 
-export PATH=<%= Shellwords.shellescape("/sbin:/usr/sbin:/bin:/usr/bin".split(":").map { |path| [File.join(root_path, path), path] }.reduce(:+).join(":")) %>
+export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map{ |x| File.join(root_path, x)} + xs).uniq.join(":")) %>
 
 TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
 TD_AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>


### PR DESCRIPTION
1. Removed `set -e` from RedHat init script to solve #42
1. Allow configuring td-agent parameters via variables (e.g. `TD_AGENT_USER`) declared in default file
1. Fixed coding style issue in init scripts
1. Add tests and tests and tests, to avoid future regression



