### PR TITLE
Don't call `start-stop-daemon --stop` twice

### DIFF
--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -14,15 +14,13 @@ teardown() {
 
 @test "restart td-agent successfully (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stop" \
-                                    "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
                                     "echo not running" \
                                     "echo started"
   stub log_end_msg "0 : true"
 
   run_service restart
   assert_output <<EOS
-stop
 stopped successfully
 started
 EOS
@@ -35,15 +33,13 @@ EOS
 
 @test "restart td-agent regardless of stop failure (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stop" \
-                                    "echo failed to stop; false" \
+  stub_path /sbin/start-stop-daemon "echo failed to stop; false" \
                                     "echo not running" \
                                     "echo started"
   stub log_end_msg "0 : true"
 
   run_service restart
   assert_output <<EOS
-stop
 failed to stop
 started
 EOS
@@ -67,14 +63,12 @@ EOS
 
 @test "failed to restart td-agent by stale process (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stop" \
-                                    "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
                                     "echo still running; false"
   stub log_end_msg "1 : false"
 
   run_service restart
   assert_output <<EOS
-stop
 stopped successfully
 EOS
   assert_failure
@@ -86,15 +80,13 @@ EOS
 
 @test "failed to restart td-agent by start failure (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stop" \
-                                    "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
                                     "echo not running" \
                                     "echo failed to start; false"
   stub log_end_msg "1 : false"
 
   run_service restart
   assert_output <<EOS
-stop
 stopped successfully
 failed to start
 EOS

--- a/bats/stop_debian.bats
+++ b/bats/stop_debian.bats
@@ -13,8 +13,7 @@ teardown() {
 }
 
 @test "stop td-agent successfully (debian)" {
-  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_end_msg "0 : true"
 
   run_service stop
@@ -27,13 +26,6 @@ start-stop-daemon
   ${TMP}/var/run/td-agent/td-agent.pid
   --name
   ruby
-start-stop-daemon
-  --stop
-  --quiet
-  --oknodo
-  --retry=0/30/KILL/5
-  --exec
-  ${TMP}/opt/td-agent/embedded/bin/ruby
 EOS
   assert_success
 
@@ -42,8 +34,7 @@ EOS
 }
 
 @test "stop td-agent but it has already been stopped (debian)" {
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "false"
+  stub_path /sbin/start-stop-daemon "true"
   stub log_end_msg "0 : true"
 
   run_service stop
@@ -55,18 +46,6 @@ EOS
 
 @test "failed to stop td-agent (debian)" {
   stub_path /sbin/start-stop-daemon "exit 2"
-  stub log_end_msg "1 : false"
-
-  run_service stop
-  assert_failure
-
-  unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
-}
-
-@test "failed to stop td-agent children processes (debian)" {
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "exit 2"
   stub log_end_msg "1 : false"
 
   run_service stop

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -119,14 +119,6 @@ do_stop() {
   local RETVAL=0
   start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "${TD_AGENT_PID_FILE}" --name ruby || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
-  # Wait for children to finish too if this is a daemon that forks
-  # and if the daemon is only ever run from this initscript.
-  # If the above conditions are not satisfied then add some other code
-  # that waits for the process to drop all resources that could be
-  # needed by services started subsequently.  A last resort is to
-  # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "${TD_AGENT_RUBY}" || RETVAL="$?"
-  [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
   rm -f "${TD_AGENT_PID_FILE}"
   return "$RETVAL"


### PR DESCRIPTION
The second `start-stop-daemon --stop`, which doesn't have `--pidfile`
option, kills all td-agents including td-agent inside a container.