### PR TITLE
Add `TD_AGENT_OPTIONS`

### DIFF
--- a/bats/compat_debian.bats
+++ b/bats/compat_debian.bats
@@ -37,11 +37,11 @@ start-stop-daemon
   td-agent
   --
   ${TMP}/usr/sbin/td-agent
-  --daemon
-  ${TMP}/var/run/custom_name/custom_name.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --daemon
+  ${TMP}/var/run/custom_name/custom_name.pid
 EOS
   assert_success
 

--- a/bats/compat_redhat.bats
+++ b/bats/compat_redhat.bats
@@ -13,6 +13,9 @@ teardown() {
 }
 
 @test "start td-agent with backward-compatible configuration (redhat)" {
+  mkdir -p "${TMP}/path/to"
+  touch "${TMP}/path/to/custom_process_bin"
+  chmod +x "${TMP}/path/to/custom_process_bin"
   rm -f "${TMP}/var/run/td-agent/custom_prog.pid"
   cat <<EOS > "${TMP}/etc/sysconfig/td-agent"
 name="custom_name"
@@ -33,11 +36,11 @@ Starting custom_name:
   td-agent
   ${TMP}/path/to/custom_process_bin
   ${TMP}/usr/sbin/td-agent
-  --group
-  td-agent
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --group
+  td-agent
   --daemon
   ${TMP}/var/run/td-agent/custom_prog.pid
 EOS

--- a/bats/configtest_debian.bats
+++ b/bats/configtest_debian.bats
@@ -19,11 +19,11 @@ teardown() {
   run_service configtest
   assert_output <<EOS
 td-agent
-  --daemon
-  ${TMP}/var/run/td-agent/td-agent.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
   --user
   td-agent
   --group

--- a/bats/configtest_redhat.bats
+++ b/bats/configtest_redhat.bats
@@ -18,11 +18,11 @@ teardown() {
   run_service configtest
   assert_output <<EOS
 td-agent
-  --group
-  td-agent
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --group
+  td-agent
   --daemon
   ${TMP}/var/run/td-agent/td-agent.pid
   --user

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -39,15 +39,16 @@ start-stop-daemon
   td-agent
   --
   ${TMP}/usr/sbin/td-agent
-  --verbose
-  --verbose
-  --daemon
-  ${TMP}/var/run/td-agent/td-agent.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
+  --verbose
+  --verbose
   --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
 EOS
   unstub_path /sbin/start-stop-daemon
+  unstub_debian
 }
 
 @test "start td-agent with custom configurations successfully (debian)" {
@@ -86,12 +87,12 @@ start-stop-daemon
   custom_td_agent_group
   --
   ${TMP}/path/to/custom_td_agent_bin_file
-  --daemon
-  ${TMP}/path/to/custom_td_agent_pid_file
   --log
   ${TMP}/path/to/custom_td_agent_log_file
   --use-v0-config
   --no-supervisor
+  --daemon
+  ${TMP}/path/to/custom_td_agent_pid_file
 EOS
   unstub_path /sbin/start-stop-daemon
   unstub getent

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -53,7 +53,8 @@ EOS
 
 @test "start td-agent with custom configurations successfully (debian)" {
   stub getent "passwd : echo custom_td_agent_user:x:501:501:,,,:/var/lib/custom_td_agent_user:/sbin/nologin"
-  stub chown true
+  stub chown "true" \
+             "true"
   stub getent "group : echo custom_td_agent_group:x:501:"
   stub log_daemon_msg true
   stub_path /sbin/start-stop-daemon "true" \

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -70,6 +70,7 @@ TD_AGENT_RUBY="${TMP}/path/to/custom_td_agent_ruby"
 TD_AGENT_BIN_FILE="${TMP}/path/to/custom_td_agent_bin_file"
 TD_AGENT_LOG_FILE="${TMP}/path/to/custom_td_agent_log_file"
 TD_AGENT_PID_FILE="${TMP}/path/to/custom_td_agent_pid_file"
+TD_AGENT_OPTIONS="--use-v0-config --no-supervisor"
 EOS
   assert_output <<EOS
 start-stop-daemon
@@ -89,7 +90,8 @@ start-stop-daemon
   ${TMP}/path/to/custom_td_agent_pid_file
   --log
   ${TMP}/path/to/custom_td_agent_log_file
-  --use-v1-config
+  --use-v0-config
+  --no-supervisor
 EOS
   unstub_path /sbin/start-stop-daemon
   unstub getent

--- a/bats/override_redhat.bats
+++ b/bats/override_redhat.bats
@@ -18,7 +18,8 @@ custom_run() {
 
 @test "start td-agent with custom arguments successfully (redhat)" {
   stub getent "passwd : echo nobody:x:100:100:,,,:/:/sbin/nologin"
-  stub chown true
+  stub chown "true" \
+             "true"
   stub getent "group : echo nogroup:x:100:"
   rm -f "${TMP}/path/to/td-agent.pid"
   stub daemon "echo; for arg; do echo \"  \$arg\"; done"
@@ -53,7 +54,8 @@ EOS
 
 @test "start td-agent with custom configurations successfully (redhat)" {
   stub getent "passwd : echo custom_td_agent_user:x:501:501:,,,:/var/lib/custom_td_agent_user:/sbin/nologin"
-  stub chown true
+  stub chown "true" \
+             "true"
   stub getent "group : echo custom_td_agent_group:x:501:"
   mkdir -p "${TMP}/path/to"
   touch "${TMP}/path/to/custom_td_agent_ruby"

--- a/bats/override_redhat.bats
+++ b/bats/override_redhat.bats
@@ -27,6 +27,7 @@ PIDFILE="${TMP}/path/to/td-agent.pid"
 TD_AGENT_ARGS="/path/to/td-agent --verbose --verbose --group nogroup --log /path/to/td-agent.log"
 EOS
   assert_output <<EOS
+Warning: Declaring \$PIDFILE in ${TMP}/etc/sysconfig/td-agent has been deprecated. Use \$TD_AGENT_PIDFILE instead.
 Starting td-agent: 
   --pidfile=${TMP}/path/to/td-agent.pid
   --user

--- a/bats/override_redhat.bats
+++ b/bats/override_redhat.bats
@@ -59,6 +59,7 @@ TD_AGENT_BIN_FILE="${TMP}/path/to/custom_td_agent_bin_file"
 TD_AGENT_LOG_FILE="${TMP}/path/to/custom_td_agent_log_file"
 TD_AGENT_PID_FILE="${TMP}/path/to/custom_td_agent_pid_file"
 TD_AGENT_LOCK_FILE="${TMP}/path/to/custom_td_agent_lock_file"
+TD_AGENT_OPTIONS="--use-v0-config --no-supervisor"
 EOS
   assert_output <<EOS
 Starting custom_td_agent_name: 
@@ -71,7 +72,8 @@ Starting custom_td_agent_name:
   custom_td_agent_group
   --log
   ${TMP}/path/to/custom_td_agent_log_file
-  --use-v1-config
+  --use-v0-config
+  --no-supervisor
   --daemon
   ${TMP}/path/to/custom_td_agent_pid_file
 EOS

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -34,11 +34,11 @@ start-stop-daemon
   td-agent
   --
   ${TMP}/usr/sbin/td-agent
-  --daemon
-  ${TMP}/var/run/td-agent/td-agent.pid
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --daemon
+  ${TMP}/var/run/td-agent/td-agent.pid
 EOS
   assert_success
 

--- a/bats/start_redhat.bats
+++ b/bats/start_redhat.bats
@@ -25,11 +25,11 @@ Starting td-agent:
   td-agent
   ${TMP}/opt/td-agent/embedded/bin/ruby
   ${TMP}/usr/sbin/td-agent
-  --group
-  td-agent
   --log
   ${TMP}/var/log/td-agent/td-agent.log
   --use-v1-config
+  --group
+  td-agent
   --daemon
   ${TMP}/var/run/td-agent/td-agent.pid
 EOS

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -110,10 +110,13 @@ init_redhat() {
 }
 
 stub_redhat() {
+  stub getent "passwd : echo td-agent:x:500:500:,,,:/var/lib/td-agent:/sbin/nologin"
   stub chown true
+  stub getent "group : echo td-agent:x:500:"
 }
 
 unstub_redhat() {
+  unstub getent
   unstub chown
 }
 

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -65,7 +65,8 @@ init_debian() {
 
 stub_debian() {
   stub getent "passwd : echo td-agent:x:500:500:,,,:/var/lib/td-agent:/sbin/nologin"
-  stub chown true
+  stub chown "true" \
+             "true"
   stub getent "group : echo td-agent:x:500:"
   stub log_daemon_msg true
 }
@@ -111,7 +112,8 @@ init_redhat() {
 
 stub_redhat() {
   stub getent "passwd : echo td-agent:x:500:500:,,,:/var/lib/td-agent:/sbin/nologin"
-  stub chown true
+  stub chown "true" \
+             "true"
   stub getent "group : echo td-agent:x:500:"
 }
 

--- a/bats/usage_debian.bats
+++ b/bats/usage_debian.bats
@@ -15,7 +15,7 @@ teardown() {
 @test "show td-agent usage on unknown action (debian)" {
   run_service unknown
   assert_output <<EOS
-Usage: ${TMP}/etc/init.d/td-agent {start|stop|status|restart|force-reload|configtest}
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|reload|restart|force-reload|status|configtest}
 EOS
   assert_failure
 }
@@ -23,7 +23,7 @@ EOS
 @test "show td-agent usage on missing action (debian)" {
   run_service
   assert_output <<EOS
-Usage: ${TMP}/etc/init.d/td-agent {start|stop|status|restart|force-reload|configtest}
+Usage: ${TMP}/etc/init.d/td-agent {start|stop|reload|restart|force-reload|status|configtest}
 EOS
   assert_failure
 }

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -71,9 +71,8 @@ if [ -n "${TD_AGENT_GROUP}" ]; then
 fi
 
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
-# TODO: uncomment
-# mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
-# chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+  chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -36,6 +36,8 @@ if [ -n "${NAME}" ]; then
 fi
 
 if [ -n "${DAEMON_ARGS}" ]; then
+# TODO: Show warning on use of `DAEMON_ARGS`
+# echo "Warning: Declaring \$DAEMON_ARGS in ${TD_AGENT_DEFAULT} has been deprecated. Use \$TD_AGENT_OPTIONS instead." 1>&2
   TD_AGENT_OPTIONS="${DAEMON_ARGS} ${TD_AGENT_OPTIONS}"
 fi
 

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -23,6 +23,7 @@ TD_AGENT_RUBY=<%= Shellwords.shellescape(File.join(root_path, install_path, "emb
 TD_AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin", "td-agent")) %>
 TD_AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
 TD_AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+TD_AGENT_OPTIONS="--use-v1-config"
 
 # Read configuration variable file if it is present
 if [ -f "${TD_AGENT_DEFAULT}" ]; then
@@ -37,7 +38,7 @@ fi
 
 DAEMON="${TD_AGENT_RUBY}" # Introduce the server's location here
 # Arguments to run the daemon with
-DAEMON_ARGS="${TD_AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${TD_AGENT_PID_FILE} --log ${TD_AGENT_LOG_FILE} --use-v1-config"
+DAEMON_ARGS="${TD_AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${TD_AGENT_PID_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -9,7 +9,6 @@
 # Description:       Treasure Data Support <support@treasure-data.com>
 ### END INIT INFO
 <% require "shellwords" %>
-# Author: Kazuki Ohta <k@treasure-data.com>
 set -e
 
 export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map { |x| File.join(root_path, x)} + xs).uniq.join(":")) %>
@@ -36,13 +35,18 @@ if [ -n "${NAME}" ]; then
   TD_AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
 fi
 
+if [ -n "${DAEMON_ARGS}" ]; then
+  TD_AGENT_OPTIONS="${DAEMON_ARGS} ${TD_AGENT_OPTIONS}"
+fi
+
 # Arguments to run the daemon with
-DAEMON_ARGS="${TD_AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${TD_AGENT_PID_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
 [ -x "${TD_AGENT_RUBY}" ] || exit 0
 
+# Source function library.
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
 . <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %>
@@ -57,12 +61,20 @@ if [ -n "${TD_AGENT_USER}" ]; then
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
   START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} -c ${TD_AGENT_USER}"
 fi
+
 if [ -n "${TD_AGENT_GROUP}" ]; then
   if ! getent group | grep -q "^${TD_AGENT_GROUP}:"; then
     echo "$0: group for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_GROUP}" >&2
     exit 1
   fi
   START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --group ${TD_AGENT_GROUP}"
+fi
+
+if [ -n "${TD_AGENT_PID_FILE}" ]; then
+# TODO: uncomment
+# mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+# chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
@@ -74,8 +86,7 @@ fi
 #
 # Function that starts the daemon/service
 #
-do_start()
-{
+do_start() {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
   ulimit -n 65536 1>/dev/null 2>&1 || true
@@ -88,7 +99,7 @@ do_start()
     ${START_STOP_DAEMON_ARGS} --test > /dev/null \
     || return 1
   start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
-    ${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
+    ${START_STOP_DAEMON_ARGS} -- ${TD_AGENT_ARGS} \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend
@@ -98,8 +109,7 @@ do_start()
 #
 # Function that stops the daemon/service
 #
-do_stop()
-{
+do_stop() {
   # Return
   #   0 if daemon has been stopped
   #   1 if daemon was already stopped
@@ -134,7 +144,7 @@ do_reload() {
 }
 
 do_configtest() {
-  eval "$DAEMON_ARGS --user ${TD_AGENT_USER} --group ${TD_AGENT_GROUP} --dry-run -q"
+  eval "${TD_AGENT_ARGS} --user ${TD_AGENT_USER} --group ${TD_AGENT_GROUP} --dry-run -q"
 }
 
 RETVAL=0
@@ -154,9 +164,6 @@ case "$1" in
   0 | 1 ) log_end_msg 0 ;;
       2 ) log_end_msg 1 ;;
   esac
-  ;;
-"status" )
-  status_of_proc "${TD_AGENT_RUBY}" "${TD_AGENT_NAME}"
   ;;
 "reload" | "force-reload" )
   #
@@ -192,14 +199,15 @@ case "$1" in
     ;;
   esac
   ;;
+"status" )
+  status_of_proc "${TD_AGENT_RUBY}" "${TD_AGENT_NAME}"
+  ;;
 "configtest" )
   do_configtest || RETVAL="$?"
   log_end_msg "$RETVAL"
   ;;
 * )
-  echo "Usage: $0 {start|stop|status|restart|force-reload|configtest}" >&2
-  exit 3
+  echo "Usage: $0 {start|stop|reload|restart|force-reload|status|configtest}" >&2
+  exit 1
   ;;
 esac
-
-:

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -36,13 +36,12 @@ if [ -n "${NAME}" ]; then
   TD_AGENT_PID_FILE="<%= root_path %>/var/run/${NAME}/${NAME}.pid"
 fi
 
-DAEMON="${TD_AGENT_RUBY}" # Introduce the server's location here
 # Arguments to run the daemon with
 DAEMON_ARGS="${TD_AGENT_BIN_FILE} $DAEMON_ARGS --daemon ${TD_AGENT_PID_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
-[ -x "$DAEMON" ] || exit 0
+[ -x "${TD_AGENT_RUBY}" ] || exit 0
 
 # Define LSB log_* functions.
 # Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
@@ -85,10 +84,10 @@ do_start()
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${DAEMON}" \
+  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
     ${START_STOP_DAEMON_ARGS} --test > /dev/null \
     || return 1
-  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${DAEMON}" \
+  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
     ${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
     || return 2
   # Add code here, if necessary, that waits for the process to be ready
@@ -115,7 +114,7 @@ do_stop()
   # that waits for the process to drop all resources that could be
   # needed by services started subsequently.  A last resort is to
   # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "${DAEMON}" || RETVAL="$?"
+  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "${TD_AGENT_RUBY}" || RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
   rm -f "${TD_AGENT_PID_FILE}"
@@ -157,7 +156,7 @@ case "$1" in
   esac
   ;;
 "status" )
-  status_of_proc "${DAEMON}" "${TD_AGENT_NAME}"
+  status_of_proc "${TD_AGENT_RUBY}" "${TD_AGENT_NAME}"
   ;;
 "reload" | "force-reload" )
   #

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -31,6 +31,7 @@ TD_AGENT_BIN_FILE=<%= Shellwords.shellescape(File.join(root_path, "usr", "sbin",
 TD_AGENT_LOG_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %>
 TD_AGENT_PID_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 TD_AGENT_LOCK_FILE=<%= Shellwords.shellescape(File.join(root_path, "var", "lock", "subsys", project_name)) %>
+TD_AGENT_OPTIONS="--use-v1-config"
 
 # timeout can be overridden from <%= File.join(root_path, "etc/sysconfig", project_name) %>
 STOPTIMEOUT=120
@@ -63,7 +64,7 @@ fi
 
 PIDFILE="${PIDFILE-${TD_AGENT_PID_FILE}}"
 DAEMON_ARGS="${DAEMON_ARGS---user ${TD_AGENT_USER}}"
-TD_AGENT_ARGS="${TD_AGENT_ARGS-${TD_AGENT_BIN_FILE} --group ${TD_AGENT_GROUP} --log ${TD_AGENT_LOG_FILE} --use-v1-config}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS-${TD_AGENT_BIN_FILE} --group ${TD_AGENT_GROUP} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
 
 if [ -n "${PIDFILE}" ]; then
   mkdir -p "$(dirname "${PIDFILE}")"

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -69,6 +69,8 @@ if [ -n "${PIDFILE}" ]; then
 fi
 
 if [ -n "${DAEMON_ARGS}" ]; then
+# TODO: Show warning on use of `DAEMON_ARGS`
+# echo "Warning: Declaring \$DAEMON_ARGS in ${TD_AGENT_DEFAULT} has been deprecated. Use \$TD_AGENT_OPTIONS instead." 1>&2
   START_STOP_DAEMON=""
   parse_daemon_args() {
     while [ -n "$1" ]; do

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -142,8 +142,8 @@ if [ -n "${TD_AGENT_USER}" ]; then
     echo "$0: user for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_USER}" >&2
     exit 1
   fi
-# mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
-# chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+  chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
   START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --user ${TD_AGENT_USER}"
 fi
 
@@ -157,7 +157,7 @@ fi
 
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
-  chown -R "${TD_AGENT_USER}:${TD_AGENT_GROUP}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -12,14 +12,12 @@
 # Default-Stop:      0 1 6
 # Required-Start:    $local_fs
 # Required-Stop:     $local_fs
-# Short-Description: <%= project_name %>'s init script
+# Short-Description: data collector for Treasure Data
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO
 <% require "shellwords" %>
-# Source function library.
-. <%= File.join(root_path, "etc/init.d/functions") %>
 
-export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map{ |x| File.join(root_path, x)} + xs).uniq.join(":")) %>
+export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map { |x| File.join(root_path, x)} + xs).uniq.join(":")) %>
 
 TD_AGENT_NAME=<%= Shellwords.shellescape(project_name) %>
 TD_AGENT_HOME=<%= Shellwords.shellescape(File.join(root_path, install_path)) %>
@@ -36,6 +34,7 @@ TD_AGENT_OPTIONS="--use-v1-config"
 # timeout can be overridden from <%= File.join(root_path, "etc/sysconfig", project_name) %>
 STOPTIMEOUT=120
 
+# Read configuration variable file if it is present
 if [ -f "${TD_AGENT_DEFAULT}" ]; then
   . "${TD_AGENT_DEFAULT}"
 fi
@@ -69,8 +68,92 @@ if [ -n "${PIDFILE}" ]; then
   TD_AGENT_PID_FILE="${PIDFILE}"
 fi
 
-DAEMON_ARGS="${DAEMON_ARGS---user ${TD_AGENT_USER}}"
-TD_AGENT_ARGS="${TD_AGENT_ARGS-${TD_AGENT_BIN_FILE} --group ${TD_AGENT_GROUP} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
+if [ -n "${DAEMON_ARGS}" ]; then
+  START_STOP_DAEMON=""
+  parse_daemon_args() {
+    while [ -n "$1" ]; do
+      case "$1" in
+      "--user="?* )
+        echo "Warning: Declaring --user in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_USER instead." 1>&2
+        TD_AGENT_USER="${1#*=}"
+        ;;
+      "--user" )
+        echo "Warning: Declaring --user in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_USER instead." 1>&2
+        shift 1
+        TD_AGENT_USER="$1"
+        ;;
+      * )
+        START_STOP_DAEMON="${START_STOP_DAEMON} $1"
+        ;;
+      esac
+      shift 1
+    done
+  }
+  parse_daemon_args ${DAEMON_ARGS}
+fi
+
+if [ -n "${TD_AGENT_ARGS}" ]; then
+  ORIG_TD_AGENT_ARGS="${TD_AGENT_ARGS}"
+  TD_AGENT_ARGS=""
+  parse_td_agent_args() {
+    while [ -n "$1" ]; do
+      case "$1" in
+      "--group="?* )
+        echo "Warning: Declaring --group in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_GROUP instead." 1>&2
+        TD_AGENT_GROUP="${1#*=}"
+        ;;
+      "--group" )
+        echo "Warning: Declaring --group in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_GROUP instead." 1>&2
+        shift 1
+        TD_AGENT_GROUP="$1"
+        ;;
+      "--user="?* )
+        echo "Warning: Declaring --user in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_USER instead." 1>&2
+        TD_AGENT_USER="${1#*=}"
+        ;;
+      "--user" )
+        echo "Warning: Declaring --user in \$DAEMON_ARGS has been deprecated. Use \$TD_AGENT_USER instead." 1>&2
+        shift 1
+        TD_AGENT_USER="$1"
+        ;;
+      * )
+        TD_AGENT_ARGS="${TD_AGENT_ARGS} $1"
+        ;;
+      esac
+      shift 1
+    done
+  }
+  parse_td_agent_args ${ORIG_TD_AGENT_ARGS}
+fi
+
+# Arguments to run the daemon with
+TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
+START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS}"
+
+# Exit if the package is not installed
+[ -x "${TD_AGENT_RUBY}" ] || exit 0
+
+# Source function library.
+. <%= File.join(root_path, "etc/init.d/functions") %>
+
+# Check the user
+if [ -n "${TD_AGENT_USER}" ]; then
+  if ! getent passwd | grep -q "^${TD_AGENT_USER}:"; then
+    echo "$0: user for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_USER}" >&2
+    exit 1
+  fi
+# mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+# chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --user ${TD_AGENT_USER}"
+fi
+
+if [ -n "${TD_AGENT_GROUP}" ]; then
+  if ! getent group | grep -q "^${TD_AGENT_GROUP}:"; then
+    echo "$0: group for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_GROUP}" >&2
+    exit 1
+  fi
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --group ${TD_AGENT_GROUP}"
+fi
 
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
@@ -79,37 +162,43 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
-# use jemalloc to avoid fragmentation
+# Use jemalloc to avoid memory fragmentation
 if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
   export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
 RETVAL=0
 
+#
+# Function that starts the daemon/service
+#
 do_start() {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
   ulimit -n 65536 1>/dev/null 2>&1 || true
   echo -n "Starting ${TD_AGENT_NAME}: "
   local RETVAL=0
-  daemon --pidfile="${TD_AGENT_PID_FILE}" $DAEMON_ARGS "${TD_AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
+  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} || RETVAL="$?"
   echo
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
 
+#
+# Function that stops the daemon/service
+#
 do_stop() {
   echo -n "Shutting down ${TD_AGENT_NAME}: "
   local RETVAL=0
   if [ -e "${TD_AGENT_PID_FILE}" ]; then
     # Use own process termination instead of killproc because killproc can't wait SIGTERM
     TD_AGENT_PID=`cat "${TD_AGENT_PID_FILE}" 2>/dev/null`
-    if [ -n "$TD_AGENT_PID" ]; then
-      <%= File.join(root_path, "bin/kill") %> "$TD_AGENT_PID" >/dev/null 2>&1 || RETVAL="$?"
+    if [ -n "${TD_AGENT_PID}" ]; then
+      <%= File.join(root_path, "bin/kill") %> "${TD_AGENT_PID}" >/dev/null 2>&1 || RETVAL="$?"
       if [ $RETVAL -eq 0 ]; then
         TIMEOUT="$STOPTIMEOUT"
         while [ $TIMEOUT -gt 0 ]; do
-          <%= File.join(root_path, "bin/kill") %> -0 "$TD_AGENT_PID" >/dev/null 2>&1 || break
+          <%= File.join(root_path, "bin/kill") %> -0 "${TD_AGENT_PID}" >/dev/null 2>&1 || break
           sleep 1
           let TIMEOUT="${TIMEOUT}-1" || true
         done
@@ -147,6 +236,9 @@ do_restart() {
   do_start
 }
 
+#
+# Function that sends a SIGHUP to the daemon/service
+#
 do_reload() {
   do_configtest || return $?
   echo -n "Reloading ${TD_AGENT_NAME}: "
@@ -157,7 +249,7 @@ do_reload() {
 }
 
 do_configtest() {
-  eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
+  eval "${TD_AGENT_ARGS} ${START_STOP_DAEMON_ARGS} --dry-run -q"
 }
 
 case "$1" in
@@ -167,11 +259,14 @@ case "$1" in
 "stop" )
   do_stop
   ;;
+"reload" )
+  do_reload
+  ;;
 "restart" )
   do_restart
   ;;
-"reload" )
-  do_reload
+"status" )
+  status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
   ;;
 "condrestart" )
   [ -f "${TD_AGENT_LOCK_FILE}" ] && do_restart || :
@@ -179,11 +274,8 @@ case "$1" in
 "configtest" )
   do_configtest
   ;;
-"status" )
-  status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
-  ;;
 * )
-  echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}"
+  echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}" >&2
   exit 1
   ;;
 esac

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -49,7 +49,9 @@ fi
 if [ -n "${prog}" ]; then
   # backward compatibility with omnibus-td-agent <= 2.2.0. will be deleted from future release.
   echo "Warning: Declaring \$prog in ${TD_AGENT_DEFAULT} for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead." 1>&2
-  [ -n "${PIDFILE}" ] || PIDFILE="<%= root_path %>/var/run/<%= project_name %>/${prog}.pid"
+  if [ -z "${PIDFILE}" ]; then
+    TD_AGENT_PID_FILE="<%= root_path %>/var/run/<%= project_name %>/${prog}.pid"
+  fi
   TD_AGENT_LOCK_FILE="<%= root_path %>/var/lock/subsys/${prog}"
   TD_AGENT_PROG_NAME="${prog}"
 else
@@ -62,14 +64,18 @@ if [ -n "${process_bin}" ]; then
   TD_AGENT_RUBY="${process_bin}"
 fi
 
-PIDFILE="${PIDFILE-${TD_AGENT_PID_FILE}}"
+if [ -n "${PIDFILE}" ]; then
+  echo "Warning: Declaring \$PIDFILE in ${TD_AGENT_DEFAULT} has been deprecated. Use \$TD_AGENT_PIDFILE instead." 1>&2
+  TD_AGENT_PID_FILE="${PIDFILE}"
+fi
+
 DAEMON_ARGS="${DAEMON_ARGS---user ${TD_AGENT_USER}}"
 TD_AGENT_ARGS="${TD_AGENT_ARGS-${TD_AGENT_BIN_FILE} --group ${TD_AGENT_GROUP} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
 
-if [ -n "${PIDFILE}" ]; then
-  mkdir -p "$(dirname "${PIDFILE}")"
-  chown -R "${TD_AGENT_USER}:${TD_AGENT_GROUP}" "$(dirname "${PIDFILE}")"
-  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${PIDFILE}"
+if [ -n "${TD_AGENT_PID_FILE}" ]; then
+  mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
+  chown -R "${TD_AGENT_USER}:${TD_AGENT_GROUP}" "$(dirname "${TD_AGENT_PID_FILE}")"
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
 # 2012/04/17 Kazuki Ohta <k@treasure-data.com>
@@ -86,7 +92,7 @@ do_start() {
   ulimit -n 65536 1>/dev/null 2>&1 || true
   echo -n "Starting ${TD_AGENT_NAME}: "
   local RETVAL=0
-  daemon --pidfile="$PIDFILE" $DAEMON_ARGS "${TD_AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
+  daemon --pidfile="${TD_AGENT_PID_FILE}" $DAEMON_ARGS "${TD_AGENT_RUBY}" $TD_AGENT_ARGS || RETVAL="$?"
   echo
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
@@ -95,9 +101,9 @@ do_start() {
 do_stop() {
   echo -n "Shutting down ${TD_AGENT_NAME}: "
   local RETVAL=0
-  if [ -e "${PIDFILE}" ]; then
+  if [ -e "${TD_AGENT_PID_FILE}" ]; then
     # Use own process termination instead of killproc because killproc can't wait SIGTERM
-    TD_AGENT_PID=`cat "$PIDFILE" 2>/dev/null`
+    TD_AGENT_PID=`cat "${TD_AGENT_PID_FILE}" 2>/dev/null`
     if [ -n "$TD_AGENT_PID" ]; then
       <%= File.join(root_path, "bin/kill") %> "$TD_AGENT_PID" >/dev/null 2>&1 || RETVAL="$?"
       if [ $RETVAL -eq 0 ]; then
@@ -131,7 +137,7 @@ do_stop() {
     fi
   fi
   echo
-  [ $RETVAL -eq 0 ] && rm -f "$PIDFILE" && rm -f "${TD_AGENT_LOCK_FILE}"
+  [ $RETVAL -eq 0 ] && rm -f "${TD_AGENT_PID_FILE}" && rm -f "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
 
@@ -174,7 +180,7 @@ case "$1" in
   do_configtest
   ;;
 "status" )
-  status -p "$PIDFILE" "${TD_AGENT_NAME}"
+  status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
   ;;
 * )
   echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}"

--- a/templates/package-scripts/td-agent/deb/postinst
+++ b/templates/package-scripts/td-agent/deb/postinst
@@ -103,7 +103,7 @@ if [ ! -e "/etc/default/<%= project_name %>" ]; then
   cat > /etc/default/<%= project_name %> <<EOF
 # This file is sourced by /bin/sh from /etc/init.d/<%= project_name %>
 # Options to pass to <%= project_name %>
-DAEMON_ARGS=""
+TD_AGENT_OPTIONS=""
 
 EOF
 fi


### PR DESCRIPTION
It's not possible to override default td-agent's options (e.g. `--use-v1-config`) for now. To be honest, it was possible with RedHat, it requires specify whole td-agent arguments in `TD_AGENT_ARGS`, though.

I added `TD_AGENT_OPTIONS` to specify extra options for td-agent. This PR was prepared to keep compatibility between existing configuration variables of `DAEMON_ARGS` and `TD_AGENT_ARGS`. So, I believe this won't break any existing installation of td-agent.