### PR TITLE
Add a function to send signal from `TD_AGENT_PID_FILE`

### DIFF
--- a/bats/compat_debian.bats
+++ b/bats/compat_debian.bats
@@ -13,12 +13,12 @@ teardown() {
 }
 
 @test "start td-agent with backward-compatibile configuration (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   cat <<EOS > "${TMP}/etc/default/td-agent"
 NAME="custom_name"
 EOS
 
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_success_msg "td-agent : true"
 
   run_service start

--- a/bats/compat_debian.bats
+++ b/bats/compat_debian.bats
@@ -19,7 +19,7 @@ EOS
 
   stub_path /sbin/start-stop-daemon "true" \
                                     "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service start
   assert_output <<EOS
@@ -47,5 +47,5 @@ EOS
   assert_success
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }

--- a/bats/compat_debian.bats
+++ b/bats/compat_debian.bats
@@ -18,12 +18,13 @@ NAME="custom_name"
 EOS
 
   stub_path /sbin/start-stop-daemon "true" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_end_msg "0 : true"
 
   run_service start
   assert_output <<EOS
 Warning: Declaring \$NAME in ${TMP}/etc/default/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
+Starting td-agent: 
 start-stop-daemon
   --start
   --quiet

--- a/bats/compat_redhat.bats
+++ b/bats/compat_redhat.bats
@@ -63,7 +63,7 @@ EOS
   run_service stop
   assert_output <<EOS
 Warning: Declaring \$prog in ${TMP}/etc/sysconfig/td-agent for customizing \$PIDFILE has been deprecated. Use \$TD_AGENT_PID_FILE instead.
-Shutting down td-agent: 
+Stopping td-agent: 
 EOS
   assert_success
   [ ! -f "${TMP}/var/lock/subsys/custom_prog" ]

--- a/bats/configtest_debian.bats
+++ b/bats/configtest_debian.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "configuration test success (debian)" {
   stub_path /usr/sbin/td-agent "echo td-agent; for arg; do echo \"  \$arg\"; done"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service configtest
   assert_output <<EOS
@@ -34,16 +34,16 @@ EOS
   assert_success
 
   unstub_path /usr/sbin/td-agent
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "configuration test failure (debian)" {
   stub_path /usr/sbin/td-agent "false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service configtest
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub log_end_msg
+  unstub log_failure_msg
 }

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -17,9 +17,9 @@ custom_run() {
 }
 
 @test "start td-agent with additional arguments successfully (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   stub_debian
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_success_msg "td-agent : true"
   custom_run <<EOS
 DAEMON_ARGS="--verbose --verbose"
@@ -57,9 +57,9 @@ EOS
   stub chown "true" \
              "true"
   stub getent "group : echo custom_td_agent_group:x:501:"
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   mkdir -p "${TMP}/path/to"
+  rm -f "${TMP}/path/to/custom_td_agent_pid_file"
+  stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   touch "${TMP}/path/to/custom_td_agent_ruby"
   chmod +x "${TMP}/path/to/custom_td_agent_ruby"
   stub log_success_msg "custom_td_agent_name : true"

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -11,17 +11,16 @@ teardown() {
 }
 
 custom_run() {
-  stub log_end_msg "0 : true"
   cat > "${TMP}/etc/default/td-agent"
   run_service "${1:-start}"
   assert_success
-  unstub log_end_msg
 }
 
 @test "start td-agent with additional arguments successfully (debian)" {
   stub_debian
   stub_path /sbin/start-stop-daemon "true" \
                                     "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub log_success_msg "td-agent : true"
   custom_run <<EOS
 DAEMON_ARGS="--verbose --verbose"
 EOS
@@ -49,6 +48,7 @@ start-stop-daemon
   ${TMP}/var/run/td-agent/td-agent.pid
 EOS
   unstub_path /sbin/start-stop-daemon
+  unstub log_success_msg
   unstub_debian
 }
 
@@ -62,6 +62,7 @@ EOS
   mkdir -p "${TMP}/path/to"
   touch "${TMP}/path/to/custom_td_agent_ruby"
   chmod +x "${TMP}/path/to/custom_td_agent_ruby"
+  stub log_success_msg "custom_td_agent_name : true"
   custom_run <<EOS
 TD_AGENT_NAME="custom_td_agent_name"
 TD_AGENT_HOME="${TMP}/path/to/custom_td_agent_home"
@@ -97,6 +98,7 @@ start-stop-daemon
   ${TMP}/path/to/custom_td_agent_pid_file
 EOS
   unstub_path /sbin/start-stop-daemon
+  unstub log_success_msg
   unstub getent
   unstub chown
 }

--- a/bats/override_debian.bats
+++ b/bats/override_debian.bats
@@ -21,11 +21,12 @@ custom_run() {
 @test "start td-agent with additional arguments successfully (debian)" {
   stub_debian
   stub_path /sbin/start-stop-daemon "true" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   custom_run <<EOS
 DAEMON_ARGS="--verbose --verbose"
 EOS
   assert_output <<EOS
+Starting td-agent: 
 start-stop-daemon
   --start
   --quiet
@@ -56,9 +57,8 @@ EOS
   stub chown "true" \
              "true"
   stub getent "group : echo custom_td_agent_group:x:501:"
-  stub log_daemon_msg true
   stub_path /sbin/start-stop-daemon "true" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   mkdir -p "${TMP}/path/to"
   touch "${TMP}/path/to/custom_td_agent_ruby"
   chmod +x "${TMP}/path/to/custom_td_agent_ruby"
@@ -75,6 +75,7 @@ TD_AGENT_PID_FILE="${TMP}/path/to/custom_td_agent_pid_file"
 TD_AGENT_OPTIONS="--use-v0-config --no-supervisor"
 EOS
   assert_output <<EOS
+Starting custom_td_agent_name: 
 start-stop-daemon
   --start
   --quiet
@@ -98,5 +99,4 @@ EOS
   unstub_path /sbin/start-stop-daemon
   unstub getent
   unstub chown
-  unstub log_daemon_msg
 }

--- a/bats/reload_debian.bats
+++ b/bats/reload_debian.bats
@@ -16,63 +16,63 @@ teardown() {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub kill "-HUP 1234 : true"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service reload
   assert_success
 
   unstub_path /usr/sbin/td-agent
   unstub kill
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "reload td-agent forcibly (debian)" {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub kill "-HUP 1234 : true"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service force-reload
   assert_success
 
   unstub_path /usr/sbin/td-agent
   unstub kill
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "failed to reload td-agent (debian)" {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub kill "-HUP 1234 : false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service reload
   assert_failure
 
   unstub_path /usr/sbin/td-agent
   unstub kill
-  unstub log_end_msg
+  unstub log_failure_msg
 }
 
 @test "failed to reload td-agent by missing pid file (debian)" {
   rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service reload
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub log_end_msg
+  unstub log_failure_msg
 }
 
 @test "failed to reload td-agent by configuration test failure (debian)" {
   stub_path /usr/sbin/td-agent "false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service reload
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub log_end_msg
+  unstub log_failure_msg
 }

--- a/bats/reload_debian.bats
+++ b/bats/reload_debian.bats
@@ -13,63 +13,56 @@ teardown() {
 }
 
 @test "reload td-agent successfully (debian)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub kill "-HUP 1234 : true"
   stub log_end_msg "0 : true"
 
   run_service reload
-  assert_output <<EOS
-start-stop-daemon
-  --stop
-  --signal
-  1
-  --quiet
-  --pidfile
-  ${TMP}/var/run/td-agent/td-agent.pid
-  --name
-  ruby
-EOS
   assert_success
 
   unstub_path /usr/sbin/td-agent
-  unstub_path /sbin/start-stop-daemon
+  unstub kill
   unstub log_end_msg
 }
 
 @test "reload td-agent forcibly (debian)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub kill "-HUP 1234 : true"
   stub log_end_msg "0 : true"
 
   run_service force-reload
-  assert_output <<EOS
-start-stop-daemon
-  --stop
-  --signal
-  1
-  --quiet
-  --pidfile
-  ${TMP}/var/run/td-agent/td-agent.pid
-  --name
-  ruby
-EOS
   assert_success
 
   unstub_path /usr/sbin/td-agent
-  unstub_path /sbin/start-stop-daemon
+  unstub kill
   unstub log_end_msg
 }
 
 @test "failed to reload td-agent (debian)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "false"
+  stub kill "-HUP 1234 : false"
   stub log_end_msg "1 : false"
 
   run_service reload
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub_path /sbin/start-stop-daemon
+  unstub kill
+  unstub log_end_msg
+}
+
+@test "failed to reload td-agent by missing pid file (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  stub_path /usr/sbin/td-agent "true"
+  stub log_end_msg "1 : false"
+
+  run_service reload
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
   unstub log_end_msg
 }
 

--- a/bats/reload_redhat.bats
+++ b/bats/reload_redhat.bats
@@ -13,33 +13,37 @@ teardown() {
 }
 
 @test "reload td-agent successfully (redhat)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub killproc "echo; for arg; do echo \"  \$arg\"; done"
+  stub kill "-HUP 1234 : true"
 
   run_service reload
-  assert_output <<EOS
-Reloading td-agent: 
-  ${TMP}/opt/td-agent/embedded/bin/ruby
-  -HUP
-EOS
   assert_success
 
   unstub_path /usr/sbin/td-agent
-  unstub killproc
+  unstub kill
 }
 
 @test "failed to reload td-agent (redhat)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
-  stub killproc "false"
+  stub kill "-HUP 1234 : false"
 
   run_service reload
-  assert_output <<EOS
-Reloading td-agent: 
-EOS
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub killproc
+  unstub kill
+}
+
+@test "failed to reload td-agent by missing pid file (redhat)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  stub_path /usr/sbin/td-agent "true"
+
+  run_service reload
+  assert_failure
+
+  unstub_path /usr/sbin/td-agent
 }
 
 @test "failed to reload td-agent by configuration test failure (redhat)" {

--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -14,13 +14,14 @@ teardown() {
 
 @test "restart td-agent successfully (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo not running" \
                                     "echo started"
   stub log_end_msg "0 : true"
 
   run_service restart
   assert_output <<EOS
+Restarting td-agent: 
 stopped successfully
 started
 EOS
@@ -33,13 +34,14 @@ EOS
 
 @test "restart td-agent regardless of stop failure (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo failed to stop; false" \
+  stub_path /sbin/start-stop-daemon "echo; echo failed to stop; false" \
                                     "echo not running" \
                                     "echo started"
   stub log_end_msg "0 : true"
 
   run_service restart
   assert_output <<EOS
+Restarting td-agent: 
 failed to stop
 started
 EOS
@@ -63,12 +65,13 @@ EOS
 
 @test "failed to restart td-agent by stale process (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo still running; false"
   stub log_end_msg "1 : false"
 
   run_service restart
   assert_output <<EOS
+Restarting td-agent: 
 stopped successfully
 EOS
   assert_failure
@@ -80,13 +83,14 @@ EOS
 
 @test "failed to restart td-agent by start failure (debian)" {
   stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo stopped successfully" \
+  stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo not running" \
                                     "echo failed to start; false"
   stub log_end_msg "1 : false"
 
   run_service restart
   assert_output <<EOS
+Restarting td-agent: 
 stopped successfully
 failed to start
 EOS

--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -13,9 +13,9 @@ teardown() {
 }
 
 @test "restart td-agent successfully (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
-                                    "echo not running" \
                                     "echo started"
   stub log_success_msg "td-agent : true"
 
@@ -33,9 +33,9 @@ EOS
 }
 
 @test "restart td-agent regardless of stop failure (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub_path /sbin/start-stop-daemon "echo; echo failed to stop; false" \
-                                    "echo not running" \
                                     "echo started"
   stub log_success_msg "td-agent : true"
 
@@ -63,28 +63,30 @@ EOS
   unstub log_failure_msg
 }
 
-@test "failed to restart td-agent by stale process (debian)" {
-  stub_path /usr/sbin/td-agent "true"
-  stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
-                                    "echo still running; false"
-  stub log_failure_msg "td-agent : false"
-
-  run_service restart
-  assert_output <<EOS
-Restarting td-agent: 
-stopped successfully
-EOS
-  assert_failure
-
-  unstub_path /usr/sbin/td-agent
-  unstub_path /sbin/start-stop-daemon
-  unstub log_failure_msg
-}
+#@test "failed to restart td-agent by stale process (debian)" {
+#  stub_path /usr/sbin/td-agent "true"
+#  stub_path /sbin/start-stop-daemon "echo; echo stopped successfully"
+#  stub kill "-0 1234 : true"
+#  stub log_failure_msg "td-agent : false"
+#
+#  run_service restart
+#  assert_output <<EOS
+#Restarting td-agent: 
+#stop
+#stopped successfully
+#EOS
+#  assert_failure
+#
+#  unstub_path /usr/sbin/td-agent
+#  unstub_path /sbin/start-stop-daemon
+#  unstub kill
+#  unstub log_failure_msg
+#}
 
 @test "failed to restart td-agent by start failure (debian)" {
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
   stub_path /usr/sbin/td-agent "true"
   stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
-                                    "echo not running" \
                                     "echo failed to start; false"
   stub log_failure_msg "td-agent : true"
 

--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -17,7 +17,7 @@ teardown() {
   stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo not running" \
                                     "echo started"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service restart
   assert_output <<EOS
@@ -29,7 +29,7 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "restart td-agent regardless of stop failure (debian)" {
@@ -37,7 +37,7 @@ EOS
   stub_path /sbin/start-stop-daemon "echo; echo failed to stop; false" \
                                     "echo not running" \
                                     "echo started"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service restart
   assert_output <<EOS
@@ -49,25 +49,25 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "failed to restart td-agent by configuration test failure (debian)" {
   stub_path /usr/sbin/td-agent "false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : false"
 
   run_service restart
   assert_failure
 
   unstub_path /usr/sbin/td-agent
-  unstub log_end_msg
+  unstub log_failure_msg
 }
 
 @test "failed to restart td-agent by stale process (debian)" {
   stub_path /usr/sbin/td-agent "true"
   stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo still running; false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : false"
 
   run_service restart
   assert_output <<EOS
@@ -78,7 +78,7 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_failure_msg
 }
 
 @test "failed to restart td-agent by start failure (debian)" {
@@ -86,7 +86,7 @@ EOS
   stub_path /sbin/start-stop-daemon "echo; echo stopped successfully" \
                                     "echo not running" \
                                     "echo failed to start; false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service restart
   assert_output <<EOS
@@ -98,5 +98,5 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_failure_msg
 }

--- a/bats/restart_redhat.bats
+++ b/bats/restart_redhat.bats
@@ -37,7 +37,7 @@ EOS
 @test "restart td-agent regardless of stop failure (redhat)" {
   stub_path /usr/sbin/td-agent "true"
   stub killproc "false"
-  stub failure "false"
+  stub success "true"
   stub daemon "true"
 
   run_service restart
@@ -48,7 +48,7 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub killproc
-  unstub failure
+  unstub success
   unstub daemon
 }
 
@@ -64,7 +64,7 @@ EOS
 @test "failed to restart td-agent by start failure (redhat)" {
   stub_path /usr/sbin/td-agent "true"
   stub killproc "true"
-  stub success "true"
+  stub failure "false"
   stub daemon "false"
 
   run_service restart
@@ -76,7 +76,7 @@ EOS
 
   unstub_path /usr/sbin/td-agent
   unstub killproc
-  unstub success
+  unstub failure
   unstub daemon
 }
 

--- a/bats/restart_redhat.bats
+++ b/bats/restart_redhat.bats
@@ -23,8 +23,7 @@ teardown() {
 
   run_service restart
   assert_output <<EOS
-Shutting down td-agent: 
-Starting td-agent: 
+Restarting td-agent: 
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -43,8 +42,7 @@ EOS
 
   run_service restart
   assert_output <<EOS
-Shutting down td-agent: 
-Starting td-agent: 
+Restarting td-agent: 
 EOS
   assert_success
 
@@ -71,8 +69,7 @@ EOS
 
   run_service restart
   assert_output <<EOS
-Shutting down td-agent: 
-Starting td-agent: 
+Restarting td-agent: 
 EOS
   assert_failure
   [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -94,8 +91,7 @@ EOS
 
   run_service condrestart
   assert_output <<EOS
-Shutting down td-agent: 
-Starting td-agent: 
+Restarting td-agent: 
 EOS
   assert_success
   [ -f "${TMP}/var/lock/subsys/td-agent" ]

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -17,7 +17,7 @@ teardown() {
 
   stub_path /sbin/start-stop-daemon "true" \
                                     "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service start
   assert_output <<EOS
@@ -44,28 +44,28 @@ EOS
   assert_success
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "start td-agent but it has already been started (debian)" {
   stub_path /sbin/start-stop-daemon "false"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service start
   assert_success
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "failed to start td-agent (debian)" {
   stub_path /sbin/start-stop-daemon "true" \
                                     "false"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service start
   assert_failure
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_failure_msg
 }

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -16,11 +16,12 @@ teardown() {
   rm -f "${TMP}/etc/default/td-agent"
 
   stub_path /sbin/start-stop-daemon "true" \
-                                    "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_end_msg "0 : true"
 
   run_service start
   assert_output <<EOS
+Starting td-agent: 
 start-stop-daemon
   --start
   --quiet

--- a/bats/start_debian.bats
+++ b/bats/start_debian.bats
@@ -14,9 +14,9 @@ teardown() {
 
 @test "start td-agent successfully (debian)" {
   rm -f "${TMP}/etc/default/td-agent"
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
 
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_success_msg "td-agent : true"
 
   run_service start
@@ -48,19 +48,20 @@ EOS
 }
 
 @test "start td-agent but it has already been started (debian)" {
-  stub_path /sbin/start-stop-daemon "false"
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  stub kill "-0 1234 : true"
   stub log_success_msg "td-agent : true"
 
   run_service start
   assert_success
 
-  unstub_path /sbin/start-stop-daemon
+  unstub kill
   unstub log_success_msg
 }
 
 @test "failed to start td-agent (debian)" {
-  stub_path /sbin/start-stop-daemon "true" \
-                                    "false"
+  rm -f "${TMP}/var/run/td-agent/td-agent.pid"
+  stub_path /sbin/start-stop-daemon "false"
   stub log_failure_msg "td-agent : true"
 
   run_service start

--- a/bats/status_debian.bats
+++ b/bats/status_debian.bats
@@ -13,23 +13,25 @@ teardown() {
 }
 
 @test "show td-agent status successfully (debian)" {
-  stub status_of_proc "for arg; do echo \$arg; done"
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  stub kill "-0 1234 : true"
+  stub log_success_msg "true"
 
   run_service status
-  assert_output <<EOS
-${TMP}/opt/td-agent/embedded/bin/ruby
-td-agent
-EOS
   assert_success
 
-  unstub status_of_proc
+  unstub kill
+  unstub log_success_msg
 }
 
 @test "failed to show td-agent status (debian)" {
-  stub status_of_proc "false"
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  stub kill "-0 1234 : false"
+  stub log_failure_msg "true"
 
   run_service status
   assert_failure
 
-  unstub status_of_proc
+  unstub kill
+  unstub log_failure_msg
 }

--- a/bats/status_redhat.bats
+++ b/bats/status_redhat.bats
@@ -13,19 +13,25 @@ teardown() {
 }
 
 @test "show td-agent status successfully (redhat)" {
-  stub status "-p ${TMP}/var/run/td-agent/td-agent.pid td-agent : true"
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  stub kill "-0 1234 : true"
+  stub log_success_msg "true"
 
   run_service status
   assert_success
 
-  unstub status
+  unstub kill
+  unstub log_success_msg
 }
 
 @test "failed to show td-agent status (redhat)" {
-  stub status "-p ${TMP}/var/run/td-agent/td-agent.pid td-agent : false"
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  stub kill "-0 1234 : false"
+  stub log_failure_msg "true"
 
   run_service status
   assert_failure
 
-  unstub status
+  unstub kill
+  unstub log_failure_msg
 }

--- a/bats/stop_debian.bats
+++ b/bats/stop_debian.bats
@@ -14,7 +14,7 @@ teardown() {
 
 @test "stop td-agent successfully (debian)" {
   stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
-  stub log_end_msg "0 : true"
+  stub log_success_msg "td-agent : true"
 
   run_service stop
   assert_output <<EOS
@@ -31,27 +31,27 @@ EOS
   assert_success
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "stop td-agent but it has already been stopped (debian)" {
-  stub_path /sbin/start-stop-daemon "true"
-  stub log_end_msg "0 : true"
+  stub_path /sbin/start-stop-daemon "false"
+  stub log_success_msg "td-agent : true"
 
   run_service stop
   assert_success
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_success_msg
 }
 
 @test "failed to stop td-agent (debian)" {
   stub_path /sbin/start-stop-daemon "exit 2"
-  stub log_end_msg "1 : false"
+  stub log_failure_msg "td-agent : true"
 
   run_service stop
   assert_failure
 
   unstub_path /sbin/start-stop-daemon
-  unstub log_end_msg
+  unstub log_failure_msg
 }

--- a/bats/stop_debian.bats
+++ b/bats/stop_debian.bats
@@ -13,11 +13,12 @@ teardown() {
 }
 
 @test "stop td-agent successfully (debian)" {
-  stub_path /sbin/start-stop-daemon "echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
+  stub_path /sbin/start-stop-daemon "echo; echo start-stop-daemon; for arg; do echo \"  \$arg\"; done"
   stub log_end_msg "0 : true"
 
   run_service stop
   assert_output <<EOS
+Stopping td-agent: 
 start-stop-daemon
   --stop
   --quiet

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -16,7 +16,8 @@ teardown() {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   touch "${TMP}/var/lock/subsys/td-agent"
 
-  stub kill "1234 : true" \
+  stub kill "-TERM 1234 : true" \
+             "-0 1234 : false" \
              "-0 1234 : false"
   stub success "true"
 
@@ -35,7 +36,7 @@ EOS
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   touch "${TMP}/var/lock/subsys/td-agent"
 
-  stub kill "1234 : false"
+  stub kill "-TERM 1234 : false"
   stub failure "false"
 
   run_service stop
@@ -57,7 +58,8 @@ EOS
 STOPTIMEOUT=3
 SH
 
-  stub kill "1234 : true" \
+  stub kill "-TERM 1234 : true" \
+            "-0 1234 : true" \
             "-0 1234 : true" \
             "-0 1234 : true" \
             "-0 1234 : true"

--- a/bats/stop_redhat.bats
+++ b/bats/stop_redhat.bats
@@ -22,7 +22,7 @@ teardown() {
 
   run_service stop
   assert_output <<EOS
-Shutting down td-agent: 
+Stopping td-agent: 
 EOS
   assert_success
   [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -40,7 +40,7 @@ EOS
 
   run_service stop
   assert_output <<EOS
-Shutting down td-agent: 
+Stopping td-agent: 
 EOS
   assert_failure # TODO: change this to success for compatibility between debian
   [ -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -66,7 +66,7 @@ SH
 
   run_service stop
   assert_output <<EOS
-Shutting down td-agent: Timeout error occurred trying to stop td-agent...
+Stopping td-agent: Timeout error occurred trying to stop td-agent...
 EOS
   assert_failure
   [ -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -84,7 +84,7 @@ EOS
 
   run_service stop
   assert_output <<EOS
-Shutting down td-agent: 
+Stopping td-agent: 
 EOS
   assert_success
   [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
@@ -102,7 +102,7 @@ EOS
 
   run_service stop
   assert_output <<EOS
-Shutting down td-agent: 
+Stopping td-agent: 
 EOS
   assert_failure
   [ -f "${TMP}/var/lock/subsys/td-agent" ]

--- a/bats/test_helper.bash
+++ b/bats/test_helper.bash
@@ -68,13 +68,11 @@ stub_debian() {
   stub chown "true" \
              "true"
   stub getent "group : echo td-agent:x:500:"
-  stub log_daemon_msg true
 }
 
 unstub_debian() {
   unstub getent
   unstub chown
-  unstub log_daemon_msg
 }
 
 init_redhat() {

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -161,7 +161,7 @@ do_configtest() {
 RETVAL=0
 case "$1" in
 "start" )
-  log_daemon_msg "Starting ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
+  echo -n "Starting ${TD_AGENT_NAME}: "
   do_start || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -169,7 +169,7 @@ case "$1" in
   esac
   ;;
 "stop" )
-  log_daemon_msg "Stopping ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
+  echo -n "Stopping ${TD_AGENT_NAME}: "
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 ) log_end_msg 0 ;;
@@ -181,7 +181,7 @@ case "$1" in
   # If do_reload() is not implemented then leave this commented out
   # and leave 'force-reload' as an alias for 'restart'.
   #
-  log_daemon_msg "Reloading ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
+  echo -n "Reloading ${TD_AGENT_NAME}: "
   do_configtest || log_end_msg 1
   do_reload || RETVAL="$?"
   log_end_msg "$RETVAL"
@@ -191,7 +191,7 @@ case "$1" in
   # If the "reload" option is implemented then remove the
   # 'force-reload' alias
   #
-  log_daemon_msg "Restarting ${TD_AGENT_NAME} " "${TD_AGENT_NAME}"
+  echo -n "Restarting ${TD_AGENT_NAME}: "
   do_configtest || log_end_msg 1
   do_stop || RETVAL="$?"
   case "$RETVAL" in

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -163,16 +163,9 @@ do_restart() {
   do_stop || val="$?"
   case "${val}" in
   0 | 1 )
-    val=0
-    do_start || val="$?"
-    case "${val}" in
-    0 )
-      :
-      ;;
-    * ) # Old process is still running, or failed to start
+    if ! do_start; then
       return 1
-      ;;
-    esac
+    fi
     ;;
   * ) # Failed to stop
     return 1
@@ -243,7 +236,12 @@ case "$1" in
   fi
   ;;
 "status" )
-  status_of_proc "${TD_AGENT_RUBY}" "${TD_AGENT_NAME}"
+  if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
+    log_success_msg "${TD_AGENT_NAME} is running"
+  else
+    log_failure_msg "${TD_AGENT_NAME} is not running"
+    exit 1
+  fi
   ;;
 "configtest" )
   if do_configtest; then

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -154,6 +154,31 @@ do_reload() {
   kill_by_file -HUP "${TD_AGENT_PID_FILE}" || return 1
 }
 
+do_restart() {
+  if ! do_configtest; then
+    return 1
+  fi
+  local val=0
+  do_stop || val="$?"
+  case "${val}" in
+  0 | 1 )
+    val=0
+    do_start || val="$?"
+    case "${val}" in
+    0 )
+      :
+      ;;
+    * ) # Old process is still running, or failed to start
+      return 1
+      ;;
+    esac
+    ;;
+  * ) # Failed to stop
+    return 1
+    ;;
+  esac
+}
+
 do_configtest() {
   eval "${TD_AGENT_ARGS} --user ${TD_AGENT_USER} --group ${TD_AGENT_GROUP} --dry-run -q"
 }
@@ -164,16 +189,26 @@ case "$1" in
   echo -n "Starting ${TD_AGENT_NAME}: "
   do_start || RETVAL="$?"
   case "$RETVAL" in
-  0 | 1 ) log_end_msg 0 ;;
-      2 ) log_end_msg 1 ;;
+  0 | 1 )
+    log_end_msg 0
+    ;;
+  * )
+    log_end_msg 1
+    exit 1
+    ;;
   esac
   ;;
 "stop" )
   echo -n "Stopping ${TD_AGENT_NAME}: "
   do_stop || RETVAL="$?"
   case "$RETVAL" in
-  0 | 1 ) log_end_msg 0 ;;
-      2 ) log_end_msg 1 ;;
+  0 | 1 )
+    log_end_msg 0
+    ;;
+  * )
+    log_end_msg 1
+    exit 1
+    ;;
   esac
   ;;
 "reload" | "force-reload" )
@@ -182,9 +217,15 @@ case "$1" in
   # and leave 'force-reload' as an alias for 'restart'.
   #
   echo -n "Reloading ${TD_AGENT_NAME}: "
-  do_configtest || log_end_msg 1
-  do_reload || RETVAL="$?"
-  log_end_msg "$RETVAL"
+  if ! do_configtest; then
+    log_end_msg 1
+    exit 1
+  fi
+  if do_reload; then
+    log_end_msg 0
+  else
+    log_end_msg 1
+  fi
   ;;
 "restart" )
   #
@@ -192,30 +233,21 @@ case "$1" in
   # 'force-reload' alias
   #
   echo -n "Restarting ${TD_AGENT_NAME}: "
-  do_configtest || log_end_msg 1
-  do_stop || RETVAL="$?"
-  case "$RETVAL" in
-  0 | 1 )
-    RETVAL=0
-    do_start || RETVAL="$?"
-    case "$RETVAL" in
-    0 ) log_end_msg 0 ;;
-    1 ) log_end_msg 1 ;; # Old process is still running
-    * ) log_end_msg 1 ;; # Failed to start
-    esac
-    ;;
-  * )
-    # Failed to stop
+  if do_restart; then
+    log_end_msg 0
+  else
     log_end_msg 1
-    ;;
-  esac
+  fi
   ;;
 "status" )
   status_of_proc "${TD_AGENT_RUBY}" "${TD_AGENT_NAME}"
   ;;
 "configtest" )
-  do_configtest || RETVAL="$?"
-  log_end_msg "$RETVAL"
+  if do_configtest; then
+    log_end_msg 0
+  else
+    log_end_msg 1
+  fi
   ;;
 * )
   echo "Usage: $0 {start|stop|reload|restart|force-reload|status|configtest}" >&2

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -114,12 +114,13 @@ do_start() {
   #   0 if daemon has been started
   #   1 if daemon was already running
   #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
-    ${START_STOP_DAEMON_ARGS} --test > /dev/null \
-    || return 1
-  start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
-    ${START_STOP_DAEMON_ARGS} -- ${TD_AGENT_ARGS} \
-    || return 2
+  if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
+    return 1
+  else
+    start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
+      ${START_STOP_DAEMON_ARGS} -- ${TD_AGENT_ARGS} \
+      || return 2
+  fi
   # Add code here, if necessary, that waits for the process to be ready
   # to handle requests from services started subsequently which depend
   # on this one.  As a last resort, sleep for some time.

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -87,6 +87,21 @@ if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
   export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
+kill_by_file() {
+  local sig="$1"
+  shift 1
+  local pid="$(cat "$@" 2>/dev/null || true)"
+  if [ -n "${pid}" ]; then
+    if <%= Shellwords.shellescape(File.join(root_path, "bin/kill")) %> "${sig}" "${pid}" 1>/dev/null 2>&1; then
+      return 0
+    else
+      return 2
+    fi
+  else
+    return 1
+  fi
+}
+
 #
 # Function that starts the daemon/service
 #
@@ -136,7 +151,7 @@ do_reload() {
   # restarting (for example, when it is sent a SIGHUP),
   # then implement that here.
   #
-  start-stop-daemon --stop --signal 1 --quiet --pidfile "${TD_AGENT_PID_FILE}" --name ruby
+  kill_by_file -HUP "${TD_AGENT_PID_FILE}" || return 1
 }
 
 do_configtest() {

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -190,10 +190,10 @@ case "$1" in
   do_start || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 )
-    log_end_msg 0
+    log_success_msg "${TD_AGENT_NAME}"
     ;;
   * )
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
     exit 1
     ;;
   esac
@@ -203,10 +203,10 @@ case "$1" in
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 | 1 )
-    log_end_msg 0
+    log_success_msg "${TD_AGENT_NAME}"
     ;;
   * )
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
     exit 1
     ;;
   esac
@@ -218,13 +218,14 @@ case "$1" in
   #
   echo -n "Reloading ${TD_AGENT_NAME}: "
   if ! do_configtest; then
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
     exit 1
   fi
   if do_reload; then
-    log_end_msg 0
+    log_success_msg "${TD_AGENT_NAME}"
   else
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
+    exit 1
   fi
   ;;
 "restart" )
@@ -234,9 +235,10 @@ case "$1" in
   #
   echo -n "Restarting ${TD_AGENT_NAME}: "
   if do_restart; then
-    log_end_msg 0
+    log_success_msg "${TD_AGENT_NAME}"
   else
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
+    exit 1
   fi
   ;;
 "status" )
@@ -244,9 +246,10 @@ case "$1" in
   ;;
 "configtest" )
   if do_configtest; then
-    log_end_msg 0
+    log_success_msg "${TD_AGENT_NAME}"
   else
-    log_end_msg 1
+    log_failure_msg "${TD_AGENT_NAME}"
+    exit 1
   fi
   ;;
 * )

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -2,11 +2,11 @@
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
 # Required-Start:    $network $local_fs
-# Required-Stop:
+# Required-Stop:     $network $local_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: data collector for Treasure Data
-# Description:       Treasure Data Support <support@treasure-data.com>
+# Description:       <%= project_name %> is a data collector
 ### END INIT INFO
 <% require "shellwords" %>
 set -e

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -245,7 +245,7 @@ do_restart() {
   do_stop || val="$?"
   case "${val}" in
   0 )
-    success
+    echo "$(success)"
     val=0
     do_start || val="$?"
     case "${val}" in
@@ -258,7 +258,7 @@ do_restart() {
     esac
     ;;
   * )
-    failure
+    echo "$(failure)"
 # TODO: change the behavior on stop failure
 #   return 1
     val=0
@@ -299,10 +299,10 @@ case "$1" in
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 )
-    success
+    echo "$(success)"
     ;;
   * )
-    failure
+    echo "$(failure)"
     exit 1
     ;;
   esac

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -186,7 +186,6 @@ do_start() {
   ulimit -n 65536 1>/dev/null 2>&1 || true
   local RETVAL=0
   daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} || RETVAL="$?"
-  echo
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
@@ -231,48 +230,96 @@ do_stop() {
       failure || true
     fi
   fi
-  echo
   [ $RETVAL -eq 0 ] && rm -f "${TD_AGENT_PID_FILE}" && rm -f "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
-}
-
-do_restart() {
-  do_configtest || return $?
-  do_stop || true
-  do_start
 }
 
 #
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-  do_configtest || return $?
+  kill_by_file -HUP "${TD_AGENT_PID_FILE}"
+}
+
+do_restart() {
+  if ! do_configtest; then
+    return 1
+  fi
   local val=0
-  kill_by_file -HUP "${TD_AGENT_PID_FILE}" || val="$?"
-  echo
-  return "${val}"
+  do_stop || val="$?"
+  case "${val}" in
+  * )
+    val=0
+    do_start || val="$?"
+    case "${val}" in
+    0 )
+      :
+      ;;
+    * ) # Old process is still running, or failed to start
+      return 1
+      ;;
+    esac
+    ;;
+# TODO: change the behavior on stop failure
+# * ) # Failed to stop
+#   return 1
+#   ;;
+  esac
 }
 
 do_configtest() {
   eval "${TD_AGENT_ARGS} ${START_STOP_DAEMON_ARGS} --dry-run -q"
 }
 
+RETVAL=0
 case "$1" in
 "start" )
   echo -n "Starting ${TD_AGENT_NAME}: "
-  do_start
+  do_start || RETVAL="$?"
+  case "$RETVAL" in
+  0 )
+    echo
+    ;;
+  * )
+    echo
+    exit 1
+    ;;
+  esac
   ;;
 "stop" )
   echo -n "Stopping ${TD_AGENT_NAME}: "
-  do_stop
+  do_stop || RETVAL="$?"
+  case "$RETVAL" in
+  0 )
+    echo
+    ;;
+  * )
+    echo
+    exit 1
+    ;;
+  esac
   ;;
 "reload" )
   echo -n "Reloading ${TD_AGENT_NAME}: "
-  do_reload
+  if ! do_configtest; then
+    echo
+    exit 1
+  fi
+  if do_reload; then
+    echo
+  else
+    echo
+    exit 1
+  fi
   ;;
 "restart" )
   echo -n "Restarting ${TD_AGENT_NAME}: "
-  do_restart
+  if do_restart; then
+    echo
+  else
+    echo
+    exit 1
+  fi
   ;;
 "status" )
   status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
@@ -280,11 +327,21 @@ case "$1" in
 "condrestart" )
   if [ -f "${TD_AGENT_LOCK_FILE}" ]; then
     echo -n "Restarting ${TD_AGENT_NAME}: "
-    do_restart
+    if do_restart; then
+      echo
+    else
+      echo
+      exit 1
+    fi
   fi
   ;;
 "configtest" )
-  do_configtest
+  if do_configtest; then
+    echo
+  else
+    echo
+    exit 1
+  fi
   ;;
 * )
   echo "Usage: $0 {start|stop|reload|restart|condrestart|status|configtest}" >&2

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -1,17 +1,10 @@
 #!/bin/bash
-#
-# <%= File.join(root_path, "etc/rc.d/init.d", project_name) %>
-#
-# chkconfig: - 80 20
-# description: <%= project_name %>
-# processname: <%= project_name %>
-# pidfile: <%= File.join(root_path, "var/run", project_name, "#{project_name}.pid") %>
-#
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Required-Start:    $local_fs
-# Required-Stop:     $local_fs
 # Short-Description: data collector for Treasure Data
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -245,32 +245,17 @@ do_restart() {
   do_stop || val="$?"
   case "${val}" in
   0 )
-    echo "$(success)"
-    val=0
-    do_start || val="$?"
-    case "${val}" in
-    0 )
-      :
-      ;;
-    * ) # Old process is still running, or failed to start
+    if ! do_start; then
       return 1
-      ;;
-    esac
+    fi
     ;;
   * )
-    echo "$(failure)"
 # TODO: change the behavior on stop failure
 #   return 1
     val=0
-    do_start || val="$?"
-    case "${val}" in
-    0 )
-      :
-      ;;
-    * ) # Old process is still running, or failed to start
+    if ! do_start; then
       return 1
-      ;;
-    esac
+    fi
     ;;
   esac
 }
@@ -323,22 +308,27 @@ case "$1" in
 "restart" )
   echo -n "Restarting ${TD_AGENT_NAME}: "
   if do_restart; then
-    echo
+    echo "$(success)"
   else
-    echo
+    echo "$(failure)"
     exit 1
   fi
   ;;
 "status" )
-  status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
+  if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
+    log_success_msg "${TD_AGENT_NAME} is running"
+  else
+    log_failure_msg "${TD_AGENT_NAME} is not running"
+    exit 1
+  fi
   ;;
 "condrestart" )
   if [ -f "${TD_AGENT_LOCK_FILE}" ]; then
     echo -n "Restarting ${TD_AGENT_NAME}: "
     if do_restart; then
-      echo
+      echo "$(success)"
     else
-      echo
+      echo "$(failure)"
       exit 1
     fi
   fi

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -184,7 +184,6 @@ do_start() {
   # Set Max number of file descriptors for the safety sake
   # see http://docs.fluentd.org/en/articles/before-install
   ulimit -n 65536 1>/dev/null 2>&1 || true
-  echo -n "Starting ${TD_AGENT_NAME}: "
   local RETVAL=0
   daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} || RETVAL="$?"
   echo
@@ -196,7 +195,6 @@ do_start() {
 # Function that stops the daemon/service
 #
 do_stop() {
-  echo -n "Shutting down ${TD_AGENT_NAME}: "
   local RETVAL=0
   if [ -e "${TD_AGENT_PID_FILE}" ]; then
     # Use own process termination instead of killproc because killproc can't wait SIGTERM
@@ -249,7 +247,6 @@ do_restart() {
 #
 do_reload() {
   do_configtest || return $?
-  echo -n "Reloading ${TD_AGENT_NAME}: "
   local val=0
   kill_by_file -HUP "${TD_AGENT_PID_FILE}" || val="$?"
   echo
@@ -262,22 +259,29 @@ do_configtest() {
 
 case "$1" in
 "start" )
+  echo -n "Starting ${TD_AGENT_NAME}: "
   do_start
   ;;
 "stop" )
+  echo -n "Stopping ${TD_AGENT_NAME}: "
   do_stop
   ;;
 "reload" )
+  echo -n "Reloading ${TD_AGENT_NAME}: "
   do_reload
   ;;
 "restart" )
+  echo -n "Restarting ${TD_AGENT_NAME}: "
   do_restart
   ;;
 "status" )
   status -p "${TD_AGENT_PID_FILE}" "${TD_AGENT_NAME}"
   ;;
 "condrestart" )
-  [ -f "${TD_AGENT_LOCK_FILE}" ] && do_restart || :
+  if [ -f "${TD_AGENT_LOCK_FILE}" ]; then
+    echo -n "Restarting ${TD_AGENT_NAME}: "
+    do_restart
+  fi
   ;;
 "configtest" )
   do_configtest

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -162,7 +162,20 @@ if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
   export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
 fi
 
-RETVAL=0
+kill_by_file() {
+  local sig="$1"
+  shift 1
+  local pid="$(cat "$@" 2>/dev/null || true)"
+  if [ -n "${pid}" ]; then
+    if <%= Shellwords.shellescape(File.join(root_path, "bin/kill")) %> "${sig}" "${pid}" 1>/dev/null 2>&1; then
+      return 0
+    else
+      return 2
+    fi
+  else
+    return 1
+  fi
+}
 
 #
 # Function that starts the daemon/service
@@ -237,10 +250,10 @@ do_restart() {
 do_reload() {
   do_configtest || return $?
   echo -n "Reloading ${TD_AGENT_NAME}: "
-  local RETVAL=0
-  killproc "${TD_AGENT_RUBY}" -HUP || RETVAL="$?"
+  local val=0
+  kill_by_file -HUP "${TD_AGENT_PID_FILE}" || val="$?"
   echo
-  return "$RETVAL"
+  return "${val}"
 }
 
 do_configtest() {

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -194,44 +194,40 @@ do_start() {
 # Function that stops the daemon/service
 #
 do_stop() {
-  local RETVAL=0
+  # Return
+  #   0 if daemon has been stopped
+  #   1 if daemon was already stopped
+  #   2 if daemon could not be stopped
+  #   other if a failure occurred
   if [ -e "${TD_AGENT_PID_FILE}" ]; then
     # Use own process termination instead of killproc because killproc can't wait SIGTERM
-    TD_AGENT_PID=`cat "${TD_AGENT_PID_FILE}" 2>/dev/null`
-    if [ -n "${TD_AGENT_PID}" ]; then
-      <%= File.join(root_path, "bin/kill") %> "${TD_AGENT_PID}" >/dev/null 2>&1 || RETVAL="$?"
-      if [ $RETVAL -eq 0 ]; then
-        TIMEOUT="$STOPTIMEOUT"
-        while [ $TIMEOUT -gt 0 ]; do
-          <%= File.join(root_path, "bin/kill") %> -0 "${TD_AGENT_PID}" >/dev/null 2>&1 || break
+    if kill_by_file -TERM "${TD_AGENT_PID_FILE}"; then
+      local i
+      for i in $(seq "${STOPTIMEOUT}"); do
+        if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
           sleep 1
-          let TIMEOUT="${TIMEOUT}-1" || true
-        done
-        if [ "$TIMEOUT" -eq 0 ]; then
-          echo -n "Timeout error occurred trying to stop ${TD_AGENT_NAME}..."
-          RETVAL=1
-          failure || true
         else
-          RETVAL=0
-          success
+          break
         fi
+      done
+      if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
+        echo -n "Timeout error occurred trying to stop ${TD_AGENT_NAME}..."
+        return 2
       else
-        failure || true
+        rm -f "${TD_AGENT_PID_FILE}"
+        rm -f "${TD_AGENT_LOCK_FILE}"
       fi
     else
-      failure || true
-      RETVAL=4
+      return 1
     fi
   else
-    killproc "${TD_AGENT_PROG_NAME:-${TD_AGENT_NAME}}" || RETVAL="$?"
-    if [ $RETVAL -eq 0 ]; then
-      success
+    if killproc "${TD_AGENT_PROG_NAME:-${TD_AGENT_NAME}}"; then
+      rm -f "${TD_AGENT_PID_FILE}"
+      rm -f "${TD_AGENT_LOCK_FILE}"
     else
-      failure || true
+      return 2
     fi
   fi
-  [ $RETVAL -eq 0 ] && rm -f "${TD_AGENT_PID_FILE}" && rm -f "${TD_AGENT_LOCK_FILE}"
-  return $RETVAL
 }
 
 #
@@ -248,7 +244,8 @@ do_restart() {
   local val=0
   do_stop || val="$?"
   case "${val}" in
-  * )
+  0 )
+    success
     val=0
     do_start || val="$?"
     case "${val}" in
@@ -260,10 +257,21 @@ do_restart() {
       ;;
     esac
     ;;
+  * )
+    failure
 # TODO: change the behavior on stop failure
-# * ) # Failed to stop
 #   return 1
-#   ;;
+    val=0
+    do_start || val="$?"
+    case "${val}" in
+    0 )
+      :
+      ;;
+    * ) # Old process is still running, or failed to start
+      return 1
+      ;;
+    esac
+    ;;
   esac
 }
 
@@ -291,10 +299,10 @@ case "$1" in
   do_stop || RETVAL="$?"
   case "$RETVAL" in
   0 )
-    echo
+    success
     ;;
   * )
-    echo
+    failure
     exit 1
     ;;
   esac


### PR DESCRIPTION
Added a same function in init script of both Debian and RedHat, to try to make their scripts common. With current impl, the actions of `reload` and `status` became common. We still need to make `do_start` and `do_stop` common eventually, but I think it requires some extra package like `redhat-lsb`.

In this PR, I believe this won't corrupt existing behaviour of the scripts. It'd be better to test on actual installation, though.