### PR TITLE
`log_success_msg` and `log_failure_msg` are not defined on RedHat

### DIFF
--- a/bats/status_redhat.bats
+++ b/bats/status_redhat.bats
@@ -15,23 +15,25 @@ teardown() {
 @test "show td-agent status successfully (redhat)" {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub kill "-0 1234 : true"
-  stub log_success_msg "true"
 
   run_service status
+  assert_output <<EOS
+td-agent is running
+EOS
   assert_success
 
   unstub kill
-  unstub log_success_msg
 }
 
 @test "failed to show td-agent status (redhat)" {
   echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
   stub kill "-0 1234 : false"
-  stub log_failure_msg "true"
 
   run_service status
+  assert_output <<EOS
+td-agent is not running
+EOS
   assert_failure
 
   unstub kill
-  unstub log_failure_msg
 }

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -316,9 +316,9 @@ case "$1" in
   ;;
 "status" )
   if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
-    log_success_msg "${TD_AGENT_NAME} is running"
+    echo "${TD_AGENT_NAME} is running"
   else
-    log_failure_msg "${TD_AGENT_NAME} is not running"
+    echo "${TD_AGENT_NAME} is not running"
     exit 1
   fi
   ;;


### PR DESCRIPTION
`log_success_msg` and `log_failure_msg` are not defined in RedHat's `/etc/init.d/functions`. They were added by my mistake :disappointed: 

We need to add `redhat-lsb` as a dependency of rpm before using them. Meanwhile, I reverted the use of those functions by `echo`.