### PR TITLE
Workaround for cacerts build breakage

### DIFF
--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -22,8 +22,6 @@ override :postgresql, :version => '9.3.5'
 if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 7
   override :liblzma, :version => '5.1.2alpha'
 end
-# workaround until https://github.com/chef/omnibus-software/pull/473 is live.
-override :ncurses, :version => '5.9'
 
 # td-agent dependencies/components
 dependency "td-agent"

--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -22,6 +22,8 @@ override :postgresql, :version => '9.3.5'
 if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 7
   override :liblzma, :version => '5.1.2alpha'
 end
+# workaround until https://github.com/chef/omnibus-software/pull/473 is live.
+override :ncurses, :version => '5.9'
 
 # td-agent dependencies/components
 dependency "td-agent"

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,11 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2015.04.22"
+default_version "2015.09.02"
+
+version "2015.09.02" do
+  source md5: "3e0e6f302bd4f5b94040b8bcee0ffe15"
+end
 
 version "2015.04.22" do
   source md5: "380df856e8f789c1af97d0da9a243769"


### PR DESCRIPTION
- Update cacerts to latest version (2015.09.02)
  - Pull chef/omnibus-software#477 into this project