### PR TITLE
Fix build break due to patch renames.

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -78,7 +78,7 @@ end
 
 build do
   if solaris2? && version.to_f >= 2.1
-    patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
+    patch source: "ruby-no-stack-protector.patch", plevel: 1
   end
 
   # AIX needs /opt/freeware/bin only for patch
@@ -93,7 +93,7 @@ build do
   # embedded and non-embedded libs get into a fight (libiconv, openssl, etc)
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
   if version.to_f >= 2.1
-    patch source: "ruby_aix_2_1_3_mkmf.patch", plevel: 1, env: patch_env
+    patch source: "ruby-2_1_3-no-mkmf.patch", plevel: 1, env: patch_env
     # should intentionally break and fail to apply on 2.2, patch will need to
     # be fixed.
   end


### PR DESCRIPTION
Pull the patch renaming changes into our copy of config/software/ruby.rb
from https://github.com/chef/omnibus-software/pull/487