### PR TITLE
Update rubygems to 2.4.8

### DIFF
--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -16,7 +16,7 @@ dependency "preparation"
 
 override :ruby, :version => '2.1.8'
 override :zlib, :version => '1.2.8'
-override :rubygems, :version => '2.2.1'
+override :rubygems, :version => '2.4.8'
 override :postgresql, :version => '9.3.5'
 
 # td-agent dependencies/components


### PR DESCRIPTION
Rubygems 2.1 has a bug with processing < and <= in gemspecs which is fixed in 2.4.8.

see https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/issues/54
and https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/commit/f33f9d04263b614425e7c2fdb2ea67536a714b6b

@trekdemo @nshttpd