### PR TITLE
To avoid dependency probrem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 # Use Berkshelf for resolving cookbook dependencies
 gem 'berkshelf', '~> 3.0'
 
+# Fork to allow for a recent version of multipart-post.
+gem 'pedump', git: 'https://github.com/ksubrama/pedump', branch: 'patch-1'
+
 # Install omnibus software
 #gem 'omnibus', '~> 5.0'
 gem 'omnibus', :github => 'chef/omnibus' # for latest omnibus-software


### PR DESCRIPTION
```
$ bundle install --binstubs
Fetching git://github.com/chef/omnibus.git
Fetching git://github.com/opscode/omnibus-software.git
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies........................................
Bundler could not find compatible versions for gem "celluloid":
  In Gemfile:
    berkshelf (~> 3.0) was resolved to 3.0.0, which depends on
      celluloid (~> 0.16.0.pre)

    berkshelf (~> 3.0) was resolved to 3.0.0, which depends on
      celluloid-io (~> 0.16.0.pre) was resolved to 0.16.5.pre0, which depends on
        celluloid (>= 0.17.0.pre12)
Bundler could not find compatible versions for gem "multipart-post":
  In Gemfile:
    berkshelf (~> 3.0) was resolved to 3.0.0, which depends on
      ridley (~> 3.0) was resolved to 3.0.0, which depends on
        faraday (~> 0.9.0) was resolved to 0.9.2, which depends on
          multipart-post (< 3, >= 1.2)

    omnibus was resolved to 5.0.0, which depends on
      pedump (~> 0.5) was resolved to 0.5.0, which depends on
        multipart-post (~> 1.1.4)
```