### PR TITLE
Fix LSB dependencies

### DIFF
--- a/config/projects/td-agent2.rb
+++ b/config/projects/td-agent2.rb
@@ -29,6 +29,17 @@ dependency "td-agent-cleanup"
 # version manifest file
 dependency "version-manifest"
 
+case ohai["os"]
+when "linux"
+  case ohai["platform_family"]
+  when "debian"
+    runtime_dependency "lsb-base"
+  when "rhel"
+    runtime_dependency "initscripts"
+    runtime_dependency "redhat-lsb-core"
+  end
+end
+
 exclude "\.git*"
 exclude "bundler\/git"
 

--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -7,16 +7,6 @@ dependency "nokogiri"
 dependency "postgresql"
 dependency "fluentd"
 
-case ohai["platform"]
-when "linux"
-  case ohai["platform_family"]
-  when "debian"
-    dependency "lsb-base"
-  when "rhel"
-    dependency "initscripts"
-    dependency "redhat-lsb"
-  end
-end
 
 env = {}
 


### PR DESCRIPTION
Fixes #78 

@repeatedly I was able to make it work by using `runtime_dependency`, along with some other changes:
- Checking `ohai["os"]` instead of `ohai["platform"]`
- Moving from the software definition to the project configuration, since `runtime_dependency` only applies to projects
- Using `redhat-lsb-core` instead of `redhat-lsb`, since `redhat-lsb` pulls in unnecessary packages like `cups` and `qt`

I've only tested this on CentOS, so I wouldn't merge the without additional testing.