### PR TITLE
Fix build error for Ruby 2.1 or later.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,7 @@ source 'https://rubygems.org'
 gem 'berkshelf', '~> 3.0'
 
 # Install omnibus software
-#gem 'omnibus', '~> 5.0'
-gem 'omnibus', :github => 'chef/omnibus' # for latest omnibus-software
+gem 'omnibus', '5.4'
 gem 'omnibus-software', :github => 'opscode/omnibus-software' #, :branch => 'omnibus/3.2-stable'
 
 # Use Test Kitchen with Vagrant for convering the build environment

--- a/config/software/fluentd.rb
+++ b/config/software/fluentd.rb
@@ -1,5 +1,6 @@
 name "fluentd"
-default_version 'aee8086e9fcd3b45fa11b83e866fd758cb79bffb'
+# fluentd v0.12.23
+default_version 'dcdbda2b0320526ad17a0601db2ab0ef8a46cb2a'
 
 dependency "ruby"
 #dependency "bundler"


### PR DESCRIPTION
Hello. fix build error for Ruby 2.1 or later.

1. fluentd default_version => fluentd v0.12.23 (latest release)
1. specify omnibus version

build environment: Ubuntu 16.04 / Ruby 2.3.1

----------
First, fix this error.
```
+ bundle exec bin/omnibus build td-agent2
The following shell command exited with status 1:
    $ /opt/td-agent/embedded/bin/gem install --no-ri --no-rdoc pkg/fluentd-*.gem
Output:
    (nothing)
Error:
    ERROR:  Error installing pkg/fluentd-0.12.20.gem:
        string-scrub requires Ruby version < 2.1, >= 1.9.3.
```

fluentd v0.12.23 including new dependency `string-scrub`
see: https://github.com/fluent/fluentd/pull/933,   https://github.com/fluent/fluentd/pull/937

----------
Second, fix this error.
```
+ bundle exec bin/omnibus build td-agent2
 /path/to/omnibus-td-agent-2.3.1/config/software/td-agent-files.rb:12:in `block (2 levels) in evaluate': undefined method `packager' for #<Omnibus::Project:0x00555e73a13340> (NoMethodError)
 Did you mean?  packagers
                package
         from /path/to/omnibus-td-agent-2.3.1/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-7c98e2bbceb7/lib/omnibus/builder.rb:1012:in `instance_eval'
```

specify omnibus gem version. packager method is unavailable at master.
see: https://github.com/chef/omnibus/pull/675

Thanks.