### PR TITLE
Use latest version of omnibus to address issue #113

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 gem 'berkshelf', '~> 3.0'
 
 # Install omnibus software
-gem 'omnibus', '5.5'
+# gem 'omnibus', '5.5'
+gem 'omnibus', :github => 'chef/omnibus' # for latest omnibus-software
 gem 'omnibus-software', :github => 'opscode/omnibus-software' #, :branch => 'omnibus/3.2-stable'
 
 # Use Test Kitchen with Vagrant for convering the build environment


### PR DESCRIPTION
Omnibus 5.5 fails to build and as noted in issue https://github.com/treasure-data/omnibus-td-agent/issues/113 the fix is to use the master omnibus branch in the Gemfile.