### PR TITLE
Updated Ruby version number to 2.2 dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ td-agent package is based on [Omnibus-ruby](https://github.com/opscode/omnibus-r
 
 ## Installation
 
-We'll assume you have Ruby 2.1 and Bundler installed. First ensure all required gems are installed and ready to use:
+We'll assume you have Ruby 2.2 and Bundler installed. First ensure all required gems are installed and ready to use:
 
 ```shell
 $ bundle install --binstubs


### PR DESCRIPTION
As 2.1 now results in the following error:

Bundler could not find compatible versions for gem "ruby ":
  In Gemfile:
    ruby

    omnibus-software was resolved to 4.0.0, which depends on
      omnibus (>= 5.5.0) was resolved to 5.5.0, which depends on
        ruby  (>= 2.2)