### PR TITLE
add pidfile chkconfig style comment to init scripts

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -8,6 +8,7 @@
 # Short-Description: data collector for Treasure Data
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO
+# pidfile:           <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 <% require "shellwords" %>
 
 export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map { |x| File.join(root_path, x)} + xs).uniq.join(":")) %>

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -8,6 +8,7 @@
 # Short-Description: data collector for Treasure Data
 # Description:       <%= project_name %> is a data collector
 ### END INIT INFO
+# pidfile:           <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 <% require "shellwords" %>
 
 export PATH=<%= xs="/sbin:/usr/sbin:/bin:/usr/bin".split(":"); Shellwords.shellescape((xs.map { |x| File.join(root_path, x)} + xs).uniq.join(":")) %>


### PR DESCRIPTION
quickfix for #125

on systemd systems, systemd-sysv-generator converts the init script into
a unit file. without the pidfile, the service will stay active even
after exiting

however this is just a quickfix, an actual service file would be better