### PR TITLE
Don't follow a symlink replace /etc/init.d/td-agent with the script no matter what is there

### DIFF
--- a/templates/package-scripts/td-agent/deb/postinst
+++ b/templates/package-scripts/td-agent/deb/postinst
@@ -81,7 +81,7 @@ case "$1" in
 esac
 
 
-cp -f ${<%= project_name_snake %>_dir}/etc/init.d/<%= project_name %> /etc/init.d/<%= project_name %>
+cp -f --remove-destination ${<%= project_name_snake %>_dir}/etc/init.d/<%= project_name %> /etc/init.d/<%= project_name %>
 cp -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %> /usr/sbin/<%= project_name %>
 chmod 755 /usr/sbin/<%= project_name %>
 cp -f ${<%= project_name_snake %>_dir}/usr/sbin/<%= project_name %>-gem /usr/sbin/<%= project_name %>-gem


### PR DESCRIPTION
This will make sure to remove whatever is there file or symlink in the install path. Currently we have an issue as after we use some logic that makes runit the main init system so it creates a symlink in the install location after the package is installed which all works fine, but when you upgrade because there is a symlink in /etc/init.d/td-agent it instead installs the init.d script at /usr/bin/sv and replaces our sv binary. This fix shouldn't be an issue for anything else as all it does is make sure to remove the symlink or file at /etc/init.d/td-agent before writing the file there. 