### PR TITLE
td-agent should be started with restart action even if the previous process has already stopped

### DIFF
--- a/bats/restart_debian.bats
+++ b/bats/restart_debian.bats
@@ -78,3 +78,24 @@ EOS
   unstub_path /sbin/start-stop-daemon
   unstub log_failure_msg
 }
+
+@test "restart should success even if the previous process has already stopped (debian)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+
+  stub_path /usr/sbin/td-agent "true"
+  stub kill "-TERM 1234 : false" \
+            "-0 1234 : false"
+  stub_path /sbin/start-stop-daemon "echo started"
+  stub log_success_msg "td-agent : true"
+
+  run_service restart
+  assert_output <<EOS
+Restarting td-agent: started
+EOS
+  assert_success
+
+  unstub_path /usr/sbin/td-agent
+  unstub kill
+  unstub_path /sbin/start-stop-daemon
+  unstub log_success_msg
+}

--- a/bats/restart_redhat.bats
+++ b/bats/restart_redhat.bats
@@ -112,3 +112,25 @@ EOS
   assert_success
   [ ! -f "${TMP}/var/lock/subsys/td-agent" ]
 }
+
+@test "restart should success even if the previous process has already stopped (debian)" {
+  echo 1234 > "${TMP}/var/run/td-agent/td-agent.pid"
+  touch "${TMP}/var/lock/subsys/td-agent"
+
+  stub_path /usr/sbin/td-agent "true"
+  stub kill "-TERM 1234 : false"
+  stub daemon "true"
+  stub log_success_msg "td-agent : true"
+
+  run_service restart
+  assert_output <<EOS
+Restarting td-agent: 
+EOS
+  assert_success
+  [ -f "${TMP}/var/lock/subsys/td-agent" ]
+
+  unstub_path /usr/sbin/td-agent
+  unstub kill
+  unstub daemon
+  unstub log_success_msg
+}

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -178,7 +178,7 @@ do_restart() {
   local val=0
   do_stop || val="$?"
   case "${val}" in
-  0 )
+  0 | 1 )
     if ! do_start; then
       return 1
     fi

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -249,7 +249,7 @@ do_restart() {
   local val=0
   do_stop || val="$?"
   case "${val}" in
-  0 )
+  0 | 1 )
     if ! do_start; then
       return 1
     fi


### PR DESCRIPTION
`do_stop` is implemented to return 1 if the process has already stopped. However, `do_restart` was  implemented to exits as error  if the previous process has already stopped.

https://github.com/treasure-data/omnibus-td-agent/blob/18041dc0072910290c504f0a0cf4ae7941ce9ad6/templates/etc/init.d/deb/td-agent#L135

According to LSB, `restart` action of init script should start service for such cases.

> restart stop and restart the service if the service is already
> running, otherwise start the service

http://refspecs.linuxbase.org/LSB_2.0.1/LSB-PDA/LSB-PDA/iniscrptact.html

(cc: @repeatedly  @mururu )