### PR TITLE
Add RuntimeDirectory to prevent unexpected error. fix #155

### DIFF
--- a/templates/etc/systemd/td-agent.service.erb
+++ b/templates/etc/systemd/td-agent.service.erb
@@ -15,6 +15,7 @@ Environment=FLUENT_CONF=/etc/<%= project_name %>/<%= project_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= project_name %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= project_name %>/<%= project_name %>.sock
 PIDFile=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+RuntimeDirectory=<%= Shellwords.shellescape(project_name) %>
 Type=forking
 ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 ExecStop=/bin/kill -TERM ${MAINPID}


### PR DESCRIPTION
I'm not sure what is the exact cause but adding `RuntimeDirectory` is better for safety when `/var/run/td-agent` is missing.

I tested new systemd file and it worked if `/var/run/td-agent` exists.