### PR TITLE
systemd: Support TD_AGENT_OPTIONS to override the command-line options.

### DIFF
--- a/templates/etc/systemd/td-agent.service.erb
+++ b/templates/etc/systemd/td-agent.service.erb
@@ -14,10 +14,11 @@ Environment=GEM_PATH=<%= install_path %>/embedded/lib/ruby/gems/<%= gem_dir_vers
 Environment=FLUENT_CONF=/etc/<%= project_name %>/<%= project_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= project_name %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= project_name %>/<%= project_name %>.sock
+Environment=TD_AGENT_OPTIONS=
 PIDFile=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 RuntimeDirectory=<%= Shellwords.shellescape(project_name) %>
 Type=forking
-ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
+ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %> $TD_AGENT_OPTIONS
 ExecStop=/bin/kill -TERM ${MAINPID}
 ExecReload=/bin/kill -HUP ${MAINPID}
 Restart=always


### PR DESCRIPTION
### Overview

In sysvinit days, we could use the env variable `TD_AGENT_OPTIONS`
to override the verbosity of td-agent (as explained in the following
documents):

https://docs.fluentd.org/v0.12/articles/trouble-shooting

This commit adds an equivalent mechanism to the systemd service file.

### Note to reviewers

For the motivation behind this patch, please see the issue #161.