### PR TITLE
Change to systemd type simple

### DIFF
--- a/templates/etc/systemd/td-agent.service.erb
+++ b/templates/etc/systemd/td-agent.service.erb
@@ -15,10 +15,9 @@ Environment=FLUENT_CONF=/etc/<%= project_name %>/<%= project_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= project_name %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= project_name %>/<%= project_name %>.sock
 Environment=TD_AGENT_OPTIONS=
-PIDFile=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 RuntimeDirectory=<%= Shellwords.shellescape(project_name) %>
-Type=forking
-ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %> $TD_AGENT_OPTIONS
+Type=simple
+ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> $TD_AGENT_OPTIONS
 ExecStop=/bin/kill -TERM ${MAINPID}
 ExecReload=/bin/kill -HUP ${MAINPID}
 Restart=always


### PR DESCRIPTION
Systemd does not require a process to daemonize.

Using `Type=simple` (where possible) is simpler and more robust.

Sources:
* https://www.freedesktop.org/software/systemd/man/daemon.html
* https://jdebp.eu/FGA/systemd-house-of-horror/daemonize.html