### PR TITLE
package-scripts: don't overwrite existing /etc/logrotate.d/td-agent

### DIFF
--- a/templates/package-scripts/td-agent/rpm/post
+++ b/templates/package-scripts/td-agent/rpm/post
@@ -39,7 +39,8 @@ fi
 
 # 2013/03/04 Kazuki Ohta <k@treasure-data.com>
 # Install log rotation script.
-if [ -d "/etc/logrotate.d/" ]; then
+if [ -d "/etc/logrotate.d/" -a ! -f "/etc/logrotate.d/<%= project_name %>" ]; then
+  echo "Installing logrotate.d config"
   cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/logrotate.d/<%= project_name %>.logrotate /etc/logrotate.d/<%= project_name %>
 fi
 


### PR DESCRIPTION
rpm upgrade is overwriting /etc/logrotate.d/td-agent all the time. There should be a way to prevent this.