### PR TITLE
update docs / Kitchen-based Build Environment

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ provisioner:
   require_chef_omnibus: 12.4.1
 
 platforms:
-  - name: centos-7.1
+  - name: centos-7.5
     run_list: yum-epel::default
   - name: centos-6.6
     run_list: yum-epel::default

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin15]
 Vagrant syncs current directory in each platform. Downloaded gems are also installed automatically.
 
 And you should not use `rbenv local` in project root because Ruby environment is built on top of rbenv in Vagrant.
-So if you set different Ruby verion in `.ruby-version`, running ruby code will fail during pacakging process. 
+So if you set different Ruby verion in `.ruby-version`, running ruby code will fail during pacakging process.
 
 ## Kitchen-based Build Environment
 
@@ -254,9 +254,11 @@ section:
 
 ```shell
 $ bundle exec kitchen login default-ubuntu-1204
-[vagrant@ubuntu...] $ cd td-agent
+[vagrant@ubuntu...] $ source load-omnibus-toolchain.sh
+[vagrant@ubuntu...] $ cd omnibus-td-agent
 [vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...
+[vagrant@ubuntu...] $ sudo install -d /opt/td-agent -o vagrant
 [vagrant@ubuntu...] $ ./bin/omnibus build td-agent3
 ```
 


### PR DESCRIPTION
- `centos-7.1` requires yum update to install the latest vboxaddon. There is no problem if it is `centos-7.5`.
- To correctly use omnibus, update the command after `kitchen login`