### PR TITLE
search local service only for td-agent group

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -148,7 +148,7 @@ if [ -n "${TD_AGENT_USER}" ]; then
 fi
 
 if [ -n "${TD_AGENT_GROUP}" ]; then
-  if ! getent group | grep -q "^${TD_AGENT_GROUP}:"; then
+  if ! getent group -s files | grep -q "^${TD_AGENT_GROUP}:"; then
     echo "$0: group for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_GROUP}" >&2
     exit 1
   fi


### PR DESCRIPTION
When nsswitch.conf is configured to use AD first (in our case centrifydc) for groups, running a 'getent group' command before the cache has synced can take a long time. With thousands of groups the td-agent service actions hang whilst it performs this lookup.

If td-agent is always a local group we can speed up the grep time by specifying the 'files' service (i.e. /etc/group) for the getent command.

Tested on RHEL 7.6.