### PR TITLE
replace `--no-ri --no-rdoc` to `--no-document`

### DIFF
--- a/bin/gem_downloader
+++ b/bin/gem_downloader
@@ -21,7 +21,7 @@ Dir.chdir(gp.target_dir) {
     path = sprintf(file_format, index, n, v)
     loop {
       `curl -o #{path} -L http://rubygems.org/downloads/#{n}-#{v}.gem`
-      `gem install --explain #{path} --no-ri --no-rdoc`
+      `gem install --explain #{path} --no-document`
       break if $?.success?
       sleep 1
     }

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -22,5 +22,5 @@ version "1.6.6"
 
 build do
   # Use 'command' instead of 'gem' to keep  previous td-agent directory structure
-  command "sudo #{install_dir}/ruby/bin/gem install bundler --no-rdoc --no-ri -v '#{version}'"
+  command "sudo #{install_dir}/ruby/bin/gem install bundler --no-document -v '#{version}'"
 end

--- a/config/software/fluentd-ui.rb
+++ b/config/software/fluentd-ui.rb
@@ -12,10 +12,10 @@ build do
   ui_gems_path = File.expand_path(File.join(Omnibus::Config.project_root, 'ui_gems'))
   if File.exist?(ui_gems_path)
     Dir.glob(File.join(ui_gems_path, '*.gem')).sort.each { |gem_path|
-      gem "install --no-ri --no-rdoc #{gem_path}"
+      gem "install --no-document #{gem_path}"
     }
     rake "build", :env => env
-    gem "install --no-ri --no-rdoc pkg/fluentd-ui-*.gem"
+    gem "install --no-document pkg/fluentd-ui-*.gem"
     td_agent_bin_dir = File.join(project.install_dir, 'embedded', 'bin')
     # Avoid deb's start-stop-daemon issue by providing another ruby binary. Will remove this ad-hoc code
     project_name_snake = project.name.gsub('-', '_')

--- a/config/software/fluentd.rb
+++ b/config/software/fluentd.rb
@@ -12,8 +12,8 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   Dir.glob(File.expand_path(File.join(Omnibus::Config.project_root, 'core_gems', '*.gem'))).sort.each { |gem_path|
-    gem "install --no-ri --no-rdoc #{gem_path}", env: env
+    gem "install --no-document #{gem_path}", env: env
   }
   rake "build", env: env
-  gem "install --no-ri --no-rdoc pkg/fluentd-*.gem", env: env
+  gem "install --no-document pkg/fluentd-*.gem", env: env
 end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -78,7 +78,7 @@ build do
 
   if source
     # Building from source:
-    ruby "setup.rb --no-ri --no-rdoc", env: env
+    ruby "setup.rb --no-document", env: env
   else
     # Installing direct from rubygems:
     # If there is no version, this will get latest.

--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -16,6 +16,6 @@ build do
       # See: https://issues.apache.org/jira/browse/THRIFT-2219
       args << " -- --with-cppflags='-D_FORTIFY_SOURCE=0'"
     end
-    gem "install --no-ri --no-rdoc #{gem_path} #{args}", :env => env
+    gem "install --no-document #{gem_path} #{args}", :env => env
   }
 end


### PR DESCRIPTION
Hi, since the `-no-ri -no-rdoc` option has been removed in rubygems 3.0.0. So, I replaced with `-no-document`.