### PR TITLE
Update kitchen file format and Use Chef 13

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,8 @@ driver:
     - ['.', '/home/vagrant/omnibus-td-agent']
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: 12.4.1
+  product_name: chef
+  product_version: 13.12.14
 
 platforms:
   - name: centos-7.5
@@ -28,6 +28,10 @@ platforms:
     run_list:
       - freebsd::portsnap
       - freebsd::pkgng
+  - name: ubuntu-18.04
+    run_list: apt::default
+  - name: ubuntu-16.04
+    run_list: apt::default
   - name: ubuntu-14.04
     run_list: apt::default
   - name: ubuntu-12.04


### PR DESCRIPTION
`kitchen converge` failed. The log is here.
```
# Build environment
$ chef --version
Chef Development Kit Version: 3.9.0
chef-client version: 14.12.3
delivery version: master (9d07501a3b347cc687c902319d23dc32dd5fa621)
berks version: 7.0.8
kitchen version: 1.24.0
inspec version: 3.9.3


$ cd omnibus-td-agent
$ bundle exec kitchen converge default-ubuntu-1404
-----> Starting Kitchen (v1.20.0)
$$$$$$ Deprecated configuration detected:
require_chef_omnibus
Run 'kitchen doctor' for details.
...
...
       Setting up chef (12.4.1-1) ...
       Thank you for installing Chef!
       Transferring files to <default-ubuntu-1404>
       Starting Chef Client, version 12.4.1
...
...
       ================================================================================
       Recipe Compile Error in /tmp/kitchen/cache/cookbooks/chef-sugar/libraries/chef-sugar.rb
       ================================================================================

       LoadError
       ---------
       cannot load such file -- chef/sugar

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/chef-sugar/libraries/chef-sugar.rb:1:in `<top (required)>'

       Relevant File Content:
       ----------------------
       /tmp/kitchen/cache/cookbooks/chef-sugar/libraries/chef-sugar.rb:

         1>> require "chef/sugar"
         2:


       Running handlers:
       [2019-05-13T07:40:41+00:00] ERROR: Running exception handlers
       Running handlers complete
       [2019-05-13T07:40:41+00:00] ERROR: Exception handlers complete
       Chef Client failed. 0 resources updated in 5.514720359 seconds
       [2019-05-13T07:40:41+00:00] FATAL: Stacktrace dumped to /tmp/kitchen/cache/chef-stacktrace.out
       [2019-05-13T07:40:41+00:00] ERROR: cannot load such file -- chef/sugar
       [2019-05-13T07:40:41+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

According to the following issue, the version of chef is the cause.
https://github.com/sethvargo/chef-sugar/issues/162

So, it is necessary to upgrade the chef when building with kitchen.
And, adding ubuntu 16 and 18 to kitchen platforms.