### PR TITLE
Add makeappex.exe instruction

### DIFF
--- a/td-agent-on-windows.md
+++ b/td-agent-on-windows.md
@@ -78,7 +78,7 @@ Download [Windows SDK](https://developer.microsoft.com/windows/downloads/windows
 The installer does not set `PATH` environment variable.
 Therefore, you have to set `PATH` to `C:\Program Files (x86)\Windows Kits\10\bin\x64`
 
-
+If you got the `makeappex.exe` is nout found error, you should also have to set `PATH` to `C:\Program Files (x86)\Windows Kits\10\bin\10.0.<BUILD NUMBER>.0\x64`.
 
 Build td-agent-3
 ----------------


### PR DESCRIPTION
I've found that the described instruction didn't cover makeappx.exe where it exists in each of Windows Kits directories.

Because makeappex.exe does not exist in C:\Program Files (x86)\Windows Kits\10\bin\x64.
Instead, it exists in C:\Program Files (x86)\Windows Kits\10\bin\10.0.<BUILD NUMBER>.0\x64.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>