### PR TITLE
Implement config file preservation for MSI

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -60,4 +60,8 @@ end
 
 package :msi do
   upgrade_code "76dcb0b2-81ad-4a07-bf3b-1db567594171"
+  parameters({
+    'InstallDir' => install_dir,
+    'TDAgentConfDir' => "#{install_dir}/etc/td-agent",
+  })
 end

--- a/resources/td-agent/msi/source.wxs.erb
+++ b/resources/td-agent/msi/source.wxs.erb
@@ -80,6 +80,21 @@
       </Directory>
     </Directory>
 
+    <DirectoryRef Id="<%= hierarchy.values.last %>">
+      <Directory Id="TDAgentEtcDir" Name="etc">
+        <Directory Id="TDAgentConfDir" Name="<%= hierarchy.keys.last %>">
+          <Component Id="TDAgentConf"
+                     Guid="534F3E10-B04E-4C17-9DAA-A390068BA8EB"
+                     Permanent="yes"
+                     NeverOverwrite="yes">
+            <File Id="TDAgentConf"
+                Name="td-agent.conf"
+                Source="$(var.TDAgentConfDir)\td-agent.conf"/>
+          </Component>
+        </Directory>
+      </Directory>
+    </DirectoryRef>
+
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
 
     <!-- Shortcut on Start Menu -->


### PR DESCRIPTION
`td-agent.conf` should be preserved during upgrading and repairing installation process.

Note that this fix will work after the next version of td-agent (parhaps 3.5.0-1?).
Because Windows installer uses registry as a marker to handle installed contents.
The previous version of td-agent does not use `NeverOverwrite` and `Permanent` attributes.
Thus, Windows installer has no idea how `td-agent.conf` should handle.

### Not working

* Upgrade from td-agent 3.4.1 or older version to the next version of td-agent.

### Working

* Repair installation with the next version of td-agent.
* Upgrade from the next version of td-agent to the two next version of td-agent.

---

Is this fix expected behavior?

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>