### PR TITLE
systemd: Support TD_AGENT_LOG_FILE to override command line options

### DIFF
--- a/templates/etc/systemd/td-agent.service.erb
+++ b/templates/etc/systemd/td-agent.service.erb
@@ -14,6 +14,7 @@ Environment=GEM_PATH=<%= install_path %>/embedded/lib/ruby/gems/<%= gem_dir_vers
 Environment=FLUENT_CONF=/etc/<%= project_name %>/<%= project_name %>.conf
 Environment=FLUENT_PLUGIN=/etc/<%= project_name %>/plugin
 Environment=FLUENT_SOCKET=/var/run/<%= project_name %>/<%= project_name %>.sock
+Environment=TD_AGENT_LOG_FILE=/var/log/<%= project_name %>/<%= project_name %>.log
 Environment=TD_AGENT_OPTIONS=
 <% if pkg_type == 'deb' %>
 EnvironmentFile=-/etc/default/<%= project_name %>
@@ -23,7 +24,7 @@ EnvironmentFile=-/etc/sysconfig/<%= project_name %>
 PIDFile=<%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %>
 RuntimeDirectory=<%= Shellwords.shellescape(project_name) %>
 Type=forking
-ExecStart=/opt/td-agent/embedded/bin/fluentd --log <%= Shellwords.shellescape(File.join(root_path, "var", "log", project_name, "#{project_name}.log")) %> --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %> $TD_AGENT_OPTIONS
+ExecStart=/opt/td-agent/embedded/bin/fluentd --log $TD_AGENT_LOG_FILE --daemon <%= Shellwords.shellescape(File.join(root_path, "var", "run", project_name, "#{project_name}.pid")) %> $TD_AGENT_OPTIONS
 ExecStop=/bin/kill -TERM ${MAINPID}
 ExecReload=/bin/kill -HUP ${MAINPID}
 Restart=always


### PR DESCRIPTION
**Motivation**

In the older init.d scripts the log path was parameterized, which allowed convenient customization using the environment file. In the new systemd `ExecStart`, the log path is hard-coded to `/var/log/td-agent/td-agent.log`. We should allow users to override the log path just like the init.d script
