### PR TITLE
Fix useradd interpolation bug in rpm post-install script

### DIFF
--- a/templates/package-scripts/td-agent/rpm/post
+++ b/templates/package-scripts/td-agent/rpm/post
@@ -7,7 +7,7 @@ echo "adding \'${PROJECT_GROUP}\' group if needed..."
 getent group "${PROJECT_GROUP}" >/dev/null || /usr/sbin/groupadd -r "${PROJECT_GROUP}"
 echo "adding \'${PROJECT_USER}\' user if needed..."
 getent passwd ${PROJECT_USER} >/dev/null || \
-  /usr/sbin/useradd -r -g ${PROJECT_GROUP} -d /var/lib/${PROJECT_USER} -s /sbin/nologin -c '${PROJECT_USER}' ${PROJECT_USER}
+  /usr/sbin/useradd -r -g ${PROJECT_GROUP} -d /var/lib/${PROJECT_USER} -s /sbin/nologin -c "${PROJECT_USER}" ${PROJECT_USER}
 
 if [ ! -e "/var/log/<%= project_name %>/" ]; then
   mkdir -p /var/log/<%= project_name %>/


### PR DESCRIPTION
`'${PROJECT_USER}'` is passed as literal string to `useradd` in the RPM post-install script

```
# rpm -qi --scripts td-agent | egrep 'Source RPM|useradd'
Source RPM  : td-agent-3.5.1-0.el7.src.rpm
  /usr/sbin/useradd -r -g ${PROJECT_GROUP} -d /var/lib/${PROJECT_USER} -s /sbin/nologin -c '${PROJECT_USER}' ${PROJECT_USER}
```

```
# getent passwd td-agent
td-agent:x:111:222:${PROJECT_USER}:/var/lib/td-agent:/sbin/nologin
```