### PR TITLE
Bundle fluent-plugin-systemd

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -55,6 +55,8 @@ if td_agent_2?
   download "fluent-plugin-record-modifier", "0.6.2"
 else
   download "fluent-plugin-record-modifier", "2.0.1"
+  download "systemd-journal", "1.3.3"
+  download "fluent-plugin-systemd", "1.0.2"
 end
 download "fluent-plugin-td-monitoring", "0.2.4"
 if windows?


### PR DESCRIPTION
Popular OSes now use systemd by default.
So bundle fluent-plugin-systemd is reasonable.