### PR TITLE
Fix librdkafka Ruby extension file ext in whitelist_file

### DIFF
--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -8,7 +8,7 @@ dependency "postgresql" unless windows?
 dependency "fluentd"
 
 # rdkafka with SASL, healthcheck blocks this file so add it to whitelist.
-whitelist_file "/opt/td-agent/embedded/lib/ruby/gems/2\.4\.0/gems/rdkafka-0\.7\.0/ext/librdkafka\.so"
+whitelist_file "/opt/td-agent[/]+embedded/lib/ruby/gems/2\.4\.0/gems/rdkafka-0\.7\.0/ext/librdkafka\.(dylib|so)"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
In macOS => .dylib
Others => .so

see: https://github.com/appsignal/rdkafka-ruby/blob/master/ext/Rakefile#L38-L41

~~And rdkafa-ruby always uses Homebrew's OpenSSL.~~
~~Should we also consider to use OpenSSL libraries in td-agent package?~~

~~see: https://github.com/appsignal/rdkafka-ruby/blob/master/ext/Rakefile#L26-L29~~

I reported the library issue in https://github.com/appsignal/rdkafka-ruby/pull/102.

I can build td-agent package in my MacBookPro with this change.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>