### PR TITLE
Tweak windows msi package

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -59,7 +59,6 @@ end
 package :msi do
   upgrade_code "76dcb0b2-81ad-4a07-bf3b-1db567594171"
   parameters({
-    'InstallDir' => install_dir,
     'TDAgentConfDir' => "#{install_dir}/etc/td-agent",
   })
 end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -141,6 +141,10 @@ elsif solaris_10?
   end
 elsif windows?
   env["CFLAGS"] = "-I#{install_dir}/embedded/include -DFD_SETSIZE=2048"
+  if version.satisfies?(">= 2.4")
+    env["CFLAGS"] << " -fstack-protector-strong"
+    env["LDFLAGS"] << " -fstack-protector-strong"
+  end
   if windows_arch_i386?
     # 32-bit windows can't compile ruby with -O2 due to compiler bugs.
     env["CFLAGS"] << " -m32 -march=i686 -O"
@@ -316,6 +320,9 @@ build do
         "libwinpthread-1",
         "libstdc++-6",
       ]
+      if version.satisfies?(">= 2.4")
+        dlls << "libssp-0"
+      end
       if windows_arch_i386?
         dlls << "libgcc_s_dw2-1"
       else

--- a/resources/td-agent/msi/source.wxs.erb
+++ b/resources/td-agent/msi/source.wxs.erb
@@ -110,6 +110,7 @@
     <Feature Id="ProjectFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="<%= wix_install_dir %>">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ApplicationShortcut" />
+      <ComponentRef Id="TDAgentConf" />
     </Feature>
 
     <!-- UI Stuff -->


### PR DESCRIPTION
### Tweak WiX package script

TDAgentConf should be added in ProjectFeature.

Otherwise we got the following WiX error but WiX creates msi package:
error LGHT0204 : ICE21: Component: 'TDAgentConf' does not belong to any Feature.

And unused InstallDir parameter should be removed parameters which are pass-throughed into WiX script.

### Make buildable with Ruby 2.5 and MSYS2's gcc

Because Ruby 2.4 or later depends on MSYS2, and MSYS2 recently uses
fortiled functions by default.
We should adopt this change on omnibus-td-agent because Ruby 2.3
had been marked as EOL in the previous year.
So, we should migrate building process on Windows to use Ruby 2.4+.

Otherwise, without this change, omnibus-td-agent complains the following error
with Ruby 2.4+ and MSYS2:

```log
Error:

    C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: array.o:array.c:(.text+0xa9f4): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: bignum.o:bignum.c:(.text+0xa8e7): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: io.o:io.c:(.text+0xa5b): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: numeric.o:numeric.c:(.text+0x2ae5): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: numeric.o:numeric.c:(.text+0x2c98): undefined reference to `__memmove_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: regerror.o:regerror.c:(.text+0x32b): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: sprintf.o:sprintf.c:(.text+0x1de2): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: string.o:string.c:(.text+0x4182): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: string.o:string.c:(.text+0x4236): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: string.o:string.c:(.text+0x429f): undefined reference to `__memcpy_chk'
C:/Ruby25-x64/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: string.o:string.c:(.text+0x4300): more undefined references to `__memcpy_chk' follow
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile:224: miniruby.exe] エラー 1
```

I tested this patch on Ruby 2.5 x64.
This issue will be cause ``undefined reference to `__memcpy_chk'`` with MSYS2.

See also: msys2/MINGW-packages#5803