### PR TITLE
Remove lsb-core dependency from RPM package

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -45,6 +45,9 @@ when "linux"
     runtime_dependency "cyrus-sasl-lib" # for rdkafka
     if ohai["platform_version"][0].to_i <= 7
       runtime_dependency "initscripts"
+      if ohai["platform_version"][0].to_i <= 6
+        runtime_dependency "redhat-lsb-core"
+      end
     end
   end
 end

--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -45,7 +45,6 @@ when "linux"
     runtime_dependency "cyrus-sasl-lib" # for rdkafka
     if ohai["platform_version"][0].to_i <= 7
       runtime_dependency "initscripts"
-      runtime_dependency "redhat-lsb-core"
     end
   end
 end

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -132,9 +132,29 @@ START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS}"
 # Source function library.
 . <%= File.join(root_path, "etc/init.d/functions") %>
 
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
-. <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %>
+# Check log_* functions definitions existence.
+if [ -f <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %> ]; then
+  # Depend on lsb-base (>= 3.0-6) to use original implementation
+  . <%= Shellwords.shellescape(File.join(root_path, "lib/lsb/init-functions")) %>
+else
+  killproc() {
+    LSB=LSB-1.1 killproc $*
+  }
+
+  log_success_msg() {
+    echo -n "$*"
+    $MOVE_TO_COL
+    echo -ne "[  OK  ]\r"
+    echo
+  }
+
+  log_failure_msg() {
+    echo -n "$*"
+    $MOVE_TO_COL
+    echo -ne "[FAILED]\r"
+    echo
+  }
+fi
 
 # Check the user
 if [ -n "${TD_AGENT_USER}" ]; then


### PR DESCRIPTION
This PR makes to remove redhat-lsb-core package runtime dependency.

I'd confirmed that rpm package building and confirmation on testkitchen's default-centos-75.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>