### PR TITLE
Use ${TD_AGENT_USER} key on getent to prevent retriving entire passwd entries

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -138,7 +138,7 @@ START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS}"
 
 # Check the user
 if [ -n "${TD_AGENT_USER}" ]; then
-  if ! getent passwd | grep -q "^${TD_AGENT_USER}:"; then
+  if ! getent passwd "${TD_AGENT_USER}" > /dev/null 2>&1; then
     echo "$0: user for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_USER}" >&2
     exit 1
   fi


### PR DESCRIPTION
getent should handle a parameter to retrieve specific key.

From man getent:

```
          passwd    When no key is provided, use setpwent(3), getpwent(3), and endpwent(3) to enumerate the passwd database.  When one or more key arguments are provided, pass each numeric  key  to
                    getpwuid(3) and each nonnumeric key to getpwnam(3) and display the result.
```

When a key for searching passwd entries is not provided, getent passwd should enumerate passwd entries entirely.
When a key for searching passwd entries is provided, getent passwd [a key] should returns an entry which is related to [a key].

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>