### PR TITLE
Use ${TD_AGENT_USER} key on getent to prevent retriving entire group entries

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -168,7 +168,7 @@ if [ -n "${TD_AGENT_USER}" ]; then
 fi
 
 if [ -n "${TD_AGENT_GROUP}" ]; then
-  if ! getent group -s files | grep -q "^${TD_AGENT_GROUP}:"; then
+  if ! getent group -s files "${TD_AGENT_GROUP}" > /dev/null 2>&1; then
     echo "$0: group for running ${TD_AGENT_NAME} doesn't exist: ${TD_AGENT_GROUP}" >&2
     exit 1
   fi


### PR DESCRIPTION
This is also needed to prevent retrieving huge group database by enumeration.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>