### PR TITLE
Remove lsb-core dependency on CentOS 6

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -45,9 +45,6 @@ when "linux"
     runtime_dependency "cyrus-sasl-lib" # for rdkafka
     if ohai["platform_version"][0].to_i <= 7
       runtime_dependency "initscripts"
-      if ohai["platform_version"][0].to_i <= 6
-        runtime_dependency "redhat-lsb-core"
-      end
     end
   end
 end


### PR DESCRIPTION
We can also remove lsb-core on CentOS 6.
If there is no lsb-core installation, users just get non-colorized
output for service command result.

And I'd confirmed that patched td-agent package should not pull lsb-core as dependent package:

```
[vagrant@default-centos-66 omnibus-td-agent]$ sudo yum install pkg/td-agent-3.8.0-0.el6.x86_64.rpm
読み込んだプラグイン:fastestmirror
インストール処理の設定をしています
pkg/td-agent-3.8.0-0.el6.x86_64.rpm を調べています: td-agent-3.8.0-0.el6.x86_64
pkg/td-agent-3.8.0-0.el6.x86_64.rpm をインストール済みとして設定しています
Loading mirror speeds from cached hostfile
 * base: ftp.tsukuba.wide.ad.jp
 * centos-sclo-rh: ftp.tsukuba.wide.ad.jp
 * centos-sclo-sclo: ftp.tsukuba.wide.ad.jp
 * epel: nrt.edge.kernel.org
 * extras: ftp.tsukuba.wide.ad.jp
 * updates: ftp.tsukuba.wide.ad.jp
依存性の解決をしています
--> トランザクションの確認を実行しています。
---> Package td-agent.x86_64 0:3.8.0-0.el6 will be インストール
--> 依存性解決を終了しました。

依存性を解決しました

=============================================================================================================================================================================
 パッケージ                          アーキテクチャ                    バージョン                              リポジトリー                                             容量
=============================================================================================================================================================================
インストールしています:
 td-agent                            x86_64                            3.8.0-0.el6                             /td-agent-3.8.0-0.el6.x86_64                            150 M

トランザクションの要約
=============================================================================================================================================================================
インストール         1 パッケージ

合計容量: 150 M
インストール済み容量: 150 M
```

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>