### PR TITLE
Bump up fluent-plugin-elasticsearch to v4.1.1

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -47,7 +47,7 @@ end
 download "fluent-plugin-kafka", "0.13.0"
 unless td_agent_2?
   download "elasticsearch", "6.8.2"
-  download "fluent-plugin-elasticsearch", "4.0.9"
+  download "fluent-plugin-elasticsearch", "4.1.1"
   download "prometheus-client", "0.9.0"
   download "fluent-plugin-prometheus", "1.8.0"
   download "fluent-plugin-prometheus_pushgateway", "0.0.2"


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

The previous version of fluent-plugin-elasticsaearch contained a bug for ILM handling when logstash_format as true.
fluent-plugin-elasticsearch v4.1.1 can handle ILM when logstash_format as true.