### PR TITLE
windows: mitigate possible escalation of privileges

### DIFF
--- a/resources/td-agent/msi/source.wxs.erb
+++ b/resources/td-agent/msi/source.wxs.erb
@@ -70,6 +70,20 @@
       <Directory Id="WINDOWSVOLUME">
 <% hierarchy.each.with_index do |(name, id), index| -%>
         <%= '  '*index %><Directory Id="<%= id %>" Name="<%= name %>">
+  <% if name == "td-agent" %>
+        <%= '  '*index %><Component Id="TDAgentAcl" Guid="b0504030-258a-0139-ba33-7085c2f4281d">
+        <%= '  '*index %>  <CreateFolder>
+        <%= '  '*index %>  <!--
+        <%= '  '*index %>    Read/Execute: Builtin Users
+        <%= '  '*index %>    All:: Builtin Administrators, Service, System account(by default)
+        <%= '  '*index %>  -->
+        <%= '  '*index %>  <Permission User="Users" GenericExecute="yes" GenericRead="yes" Traverse="yes"/>
+        <%= '  '*index %>  <Permission User="Administrators" GenericAll="yes" Traverse="yes"/>
+        <%= '  '*index %>  <Permission User="NT SERVICE\TrustedInstaller" GenericAll="yes" Traverse="yes"/>
+        <%= '  '*index %>  <Permission User="CREATOR OWNER" GenericAll="yes" Traverse="yes"/>
+        <%= '  '*index %>  </CreateFolder>
+        <%= '  '*index %></Component>
+  <% end %>
 <% end -%>
 <% hierarchy.keys.each.with_index do |_, index| -%>
         <%= '  '*(hierarchy.size - index-1) %></Directory>
@@ -111,6 +125,7 @@
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="TDAgentConf" />
+      <ComponentRef Id="TDAgentAcl" />
     </Feature>
 
     <!-- UI Stuff -->


### PR DESCRIPTION
Reported by @zubrahzz

ref. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28169

In the previous version, NT AUTHORITY\Authenticated Users:(I)(M) is
granted. It means that logged in users can replace any files under
opt/td-agent/bin. It also allows for attacker to gain administrative
privileges by replacing these files because these files are executed
as a local services with SYSTEM privilege.

Note that this PR was merged, we need to update gems
by td-agent-gem with administraror privilege.

