### PR TITLE
Use nokogiri 1.10.10 constraint

### DIFF
--- a/config/projects/td-agent3.rb
+++ b/config/projects/td-agent3.rb
@@ -24,6 +24,7 @@ override :zlib, :version => '1.2.11'
 override :jemalloc, :version => '4.5.0'
 override :rubygems, :version => '2.6.14'
 override :postgresql, :version => '9.6.9'
+override :nokogiri, :version => '1.10.10'
 override :fluentd, :version => '24fe4cbc50d1ea1e053eb6d336e6fc0f797eeb12' # v1.11.5
 
 # td-agent dependencies/components


### PR DESCRIPTION
Because nokogiri 1.11.0 requests to use Ruby 2.5 or later.
omnibus-td-agent still needs to stay on Ruby 2.4.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>