### PR TITLE
Building td agent 3.8.1 on windows

### DIFF
--- a/core_gems.rb
+++ b/core_gems.rb
@@ -12,6 +12,10 @@ else
   # To stay on Ruby 2.4.
   download "protocol-http", "0.15.1"
   download "protocol-http2", "0.11.6"
+  # To prevent nio4r's native extension building error
+  # due to devkit requiring forcibly.
+  # ref: https://github.com/socketry/nio4r/blob/master/ext/nio4r/extconf.rb#L7
+  download "nio4r", "2.5.2"
   download "async", "1.24.2"
   download "async-io", "1.27.7"
   download "async-pool", "0.2.0"

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -9,6 +9,9 @@ else
   download 'serverengine', '2.2.2'
   download "oj", "3.8.1"
   download "console", "1.8.2"
+  # To stay on Ruby 2.4.
+  download "protocol-http", "0.15.1"
+  download "protocol-http2", "0.11.6"
   download "async", "1.24.2"
   download "async-io", "1.27.7"
   download "async-pool", "0.2.0"


### PR DESCRIPTION
I'd succeeded to build td-agent 3.8.1 with these changes.

* Specify protocol-http/http2 version explicitly to stay Ruby 2.4 world
* Use nio4r 2.5.2 to avoid devkit which is provided by RubyInstaller2's Ruby requiring forcibly